### PR TITLE
Add MCP server for AI-driven .NET debugging (MAG-39)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+          dotnet-quality: 'ga'
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build -c Release --no-restore
+
+      - name: Test
+        run: dotnet test -c Release --no-build --verbosity normal
+
+      - name: Pack (sanity check)
+        if: matrix.os == 'ubuntu-latest'
+        run: dotnet pack src/AspNetCoreDebuggerMcp -c Release --no-build -o nupkg
+
+      - name: Upload package artifact
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: nupkg
+          path: nupkg/*.nupkg
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 bin/
 obj/
 out/
+nupkg/
 
 # .NET
 *.user

--- a/AspNetCoreDebuggerMcp.slnx
+++ b/AspNetCoreDebuggerMcp.slnx
@@ -1,0 +1,8 @@
+<Solution>
+  <Folder Name="/src/">
+    <Project Path="src/AspNetCoreDebuggerMcp/AspNetCoreDebuggerMcp.csproj" />
+  </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/AspNetCoreDebuggerMcp.Tests/AspNetCoreDebuggerMcp.Tests.csproj" />
+  </Folder>
+</Solution>

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # aspnetcore-debugger-mcp
 
-An MIT-licensed [Model Context Protocol](https://modelcontextprotocol.io/) server that gives AI agents
-interactive debugging capabilities for .NET / ASP.NET Core applications.
+An MIT-licensed [Model Context Protocol](https://modelcontextprotocol.io/) server that gives AI
+agents interactive debugging for .NET / ASP.NET Core applications.
 
-It lets an AI agent (Claude, etc.) **run and debug a .NET app the way a developer would** — launch or
-attach to a process, set breakpoints, step through code, inspect real variable values, catch exceptions
-with full context, and test fixes live.
+It lets an AI agent (Claude, etc.) **run and debug a .NET app the way a developer would** — launch
+or attach to a process, set breakpoints (line, conditional, hit-count, logpoint, function,
+exception, data), step through code, inspect real variable values, evaluate expressions, **mutate
+state mid-run** to test fixes, get a one-call exception autopsy, and diagnose hangs.
 
 ## How it works
 
@@ -16,19 +17,155 @@ Claude (MCP client)
 aspnetcore-debugger-mcp        ← this server
    │  DAP  (Debug Adapter Protocol)
    ▼
-netcoredbg                     ← MIT debugger engine, runs as a child process
+netcoredbg                     ← MIT debugger engine, child process
    │  ICorDebug
    ▼
 target .NET process
 ```
 
 The server is a protocol bridge: an MCP server on one side, a DAP client on the other. It drives
-`netcoredbg` (Samsung's MIT-licensed .NET debugger) and adds higher-level, agent-friendly tools on top.
+[`netcoredbg`](https://github.com/Samsung/netcoredbg) (Samsung's MIT-licensed .NET debugger) and
+adds higher-level, agent-friendly composites — including a one-call `exception_autopsy`, `hang_analyze`
+across all threads, and auto-context (top frame + source snippet) on every stop.
 
-## Status
+## Install
 
-Early development. See [SPEC.md](SPEC.md) for scope and [STATUS.md](STATUS.md) for current state.
+You need **three** things: the .NET 10 SDK, `netcoredbg`, and this tool.
+
+### 1. .NET 10 SDK
+
+Install from [dotnet.microsoft.com/download](https://dotnet.microsoft.com/download).
+
+### 2. netcoredbg
+
+| Platform              | Get it from                                                                                                  |
+|-----------------------|--------------------------------------------------------------------------------------------------------------|
+| Linux x64 / arm64     | [Samsung release](https://github.com/Samsung/netcoredbg/releases) — extract anywhere                          |
+| Windows x64           | [Samsung release](https://github.com/Samsung/netcoredbg/releases) — extract anywhere                          |
+| macOS Intel (x64)     | [Samsung release](https://github.com/Samsung/netcoredbg/releases) — extract anywhere                          |
+| **macOS Apple Silicon (arm64)** | **No prebuilt** — Samsung doesn't ship one. Build from source with `scripts/build-netcoredbg-macos-arm64.sh` |
+
+Tell the server where the binary lives via one of:
+
+- Set `NETCOREDBG_PATH` to the absolute path of the `netcoredbg` binary (recommended)
+- Or place `netcoredbg` on your `PATH`
+- Or place it next to this tool's assembly
+
+### 3. The MCP server
+
+```bash
+dotnet tool install -g AspNetCoreDebuggerMcp --prerelease
+```
+
+Run it directly to verify:
+
+```bash
+NETCOREDBG_PATH=/path/to/netcoredbg aspnetcore-debugger-mcp
+```
+
+## Configure with an MCP client
+
+### Claude Code
+
+Add to `.mcp.json` in your project (or the user-wide config):
+
+```json
+{
+  "mcpServers": {
+    "aspnetcore-debugger": {
+      "command": "aspnetcore-debugger-mcp",
+      "env": {
+        "NETCOREDBG_PATH": "/absolute/path/to/netcoredbg"
+      }
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "aspnetcore-debugger": {
+      "command": "aspnetcore-debugger-mcp",
+      "env": {
+        "NETCOREDBG_PATH": "/absolute/path/to/netcoredbg"
+      }
+    }
+  }
+}
+```
+
+## Tools (22)
+
+| Category | Tools |
+|---|---|
+| **Session** | `debug_launch`, `debug_attach`, `debug_disconnect`, `debug_state` |
+| **Breakpoints** | `breakpoint_set` (line + conditional + hit-count + logpoint), `breakpoint_set_function`, `breakpoint_set_exception`, `breakpoint_set_data`, `breakpoint_remove`, `breakpoint_list` |
+| **Execution** | `debug_continue`, `debug_pause`, `debug_step` (in/over/out), `breakpoint_wait` (blocks until next stop, with top frame + source snippet) |
+| **Inspection** | `threads_list`, `stacktrace_get`, `variables_get` (recursive expansion + truncation), `evaluate`, `variables_set` |
+| **Diagnostics** | `exception_autopsy` (one call: exception chain + frames + top-frame locals + source snippet), `hang_analyze` (auto-pause + classify each thread's blocking primitive), `process_read_output` (drain buffered stdout/stderr) |
+
+## Example session
+
+```
+You:    Debug my app and find why GetUser returns null.
+
+Claude: [debug_launch program=bin/Debug/net10.0/MyApp.dll stopAtEntry=true]
+        [breakpoint_set sourcePath=…/UserService.cs line=42]
+        [debug_continue]
+        [breakpoint_wait]   →  stopped at UserService.cs:42 (snippet attached)
+        [variables_get]      →  Locals: userId="" (empty string!)
+        [evaluate "users.Count"] → 1247
+        I found the issue: the caller is passing an empty userId. Want me to test
+        a fix by setting a real value and continuing?
+
+You:    Yes, try userId = "u-001".
+
+Claude: [variables_set expression=userId value="\"u-001\""]
+        [debug_continue]
+        [breakpoint_wait]   →  function returned successfully with a user.
+        Confirmed — the bug is in the caller (empty userId). Here's the fix…
+```
+
+## macOS Apple Silicon — build netcoredbg
+
+Samsung doesn't publish an arm64 macOS build of netcoredbg. Use the included script:
+
+```bash
+./scripts/build-netcoredbg-macos-arm64.sh
+```
+
+Requirements: Xcode Command Line Tools, CMake (`brew install cmake`), .NET 10 SDK. The script clones
+`Samsung/netcoredbg`, configures, builds, and prints the `NETCOREDBG_PATH` to export.
+
+> Samsung notes the arm64 macOS build is "community supported and may not work as expected." In our
+> testing on Apple Silicon, the build succeeds and the full debugger functionality used by this
+> project (launch, breakpoints, step, inspect, evaluate, setExpression, exceptionInfo, output
+> events) works correctly. `dataBreakpointInfo` returns `E_NOTIMPL` — see "Known limits" below.
+
+## Known limits
+
+- **`breakpoint_set_data` depends on the adapter.** netcoredbg currently returns `E_NOTIMPL` for
+  `dataBreakpointInfo`. The tool surfaces this as a clean error; if/when netcoredbg adds support,
+  the tool will just work.
+- **`process_write_input` is not implemented.** DAP launch mode owns the debuggee's stdin; piping
+  input would require a different launch architecture (launch the process ourselves, have
+  netcoredbg attach).
+
+## Build from source
+
+```bash
+git clone https://github.com/magna-nz/aspnetcore-debugger-mcp.git
+cd aspnetcore-debugger-mcp
+dotnet build
+dotnet test
+NETCOREDBG_PATH=/path/to/netcoredbg dotnet run --project src/AspNetCoreDebuggerMcp
+```
 
 ## License
 
-MIT — see [LICENSE](LICENSE). Bundles `netcoredbg` (also MIT).
+MIT — see [LICENSE](LICENSE). Depends on `netcoredbg` (also MIT) and the `ModelContextProtocol` SDK.

--- a/STATUS.md
+++ b/STATUS.md
@@ -9,6 +9,11 @@
   request/response correlation + event dispatch). netcoredbg process lifecycle. Session state
   machine + handshake. Four MCP tools (debug_launch / _attach / _disconnect / _state). 14 unit
   tests passing. End-to-end smoke test passes against the real netcoredbg + a real test .NET app.
+- WAVE 2 COMPLETE: breakpoints + execution control. BreakpointRegistry (intent-tracking, used to
+  re-send the full per-source set on every mutation). StopWaiter (TCS waiter with Reset/Terminate
+  semantics for breakpoint_wait). 9 new MCP tools: breakpoint_set / _set_function / _remove /
+  _list / _set_exception, debug_continue / _pause / _step, breakpoint_wait. 27 unit tests passing.
+  End-to-end Wave 2 smoke passes: set BP, continue, hit BP, step over, remove, continue to exit.
 
 ## Decisions made
 - **Approach:** MCP server that wraps `netcoredbg` (MIT) over the Debug Adapter Protocol — chosen
@@ -21,14 +26,13 @@
   Roslyn code navigation is out of scope.
 
 ## Where we left off
-- Wave 1 done on branch `feature/MAG-39-debugger-mcp`. Linear ticket: MAG-39.
-- Smoke test: launch TestApp.dll with stopAtEntry → state Running → async entry-stop → state Paused
-  with lastStop reason=entry → disconnect clean. The whole MCP → DAP → ICorDebug chain works.
-- Awaiting user "go" for Wave 2 (breakpoints + execution control).
+- Wave 2 done on branch `feature/MAG-39-debugger-mcp`. Linear ticket: MAG-39.
+- 13 MCP tools live, all unit + smoke tests green. Awaiting user "go" for Wave 3.
 
 ## What's next
-1. Wave 2 (needs user "go"): breakpoint_set/_function/_remove/_list/_set_exception,
-   debug_continue/pause/step, breakpoint_wait.
+1. Wave 3 (needs user "go" — MVP completes here): threads_list, stacktrace_get, variables_get
+   (recursive expansion + collection summarisation), evaluate, variables_set, exception_autopsy,
+   auto-context-on-stop.
 2. Run NETCOREDBG_PATH=~/projects/netcoredbg-src/bin/netcoredbg when launching the server until
    bundling is sorted (Wave 5).
 
@@ -44,3 +48,8 @@
   client must track `breakpoint` events, not just the `setBreakpoints` response.
 - DAP launch flow confirmed: initialize → (response) → launch → `initialized` event →
   setBreakpoints → configurationDone → process runs → `stopped` event.
+- DAP client serialises requests with `WhenWritingNull` — netcoredbg's parser rejects null
+  string fields (breakpoint condition / hitCondition / logMessage). Required for setBreakpoints.
+- StopWaiter is Reset() synchronously inside ContinueAsync/StepAsync (before the DAP request is
+  sent) so a wait registered immediately after sees a fresh TCS. Resetting on the `continued`
+  event instead would race the agent.

--- a/STATUS.md
+++ b/STATUS.md
@@ -33,6 +33,15 @@
   breakpoint_set_data, process_read_output. 44 unit tests passing. End-to-end Wave 4 smoke
   validates hang_analyze classifying threads and process_read_output capturing "Sum: 30".
   Enum responses now serialize as camelCase strings (e.g. "blockedOnMonitor"), not ints.
+- WAVE 5 COMPLETE: packaging + docs. csproj wired for PackAsTool with ToolCommandName
+  "aspnetcore-debugger-mcp", PackageId AspNetCoreDebuggerMcp, version 0.1.0-preview, MIT
+  license, README packed in. Full README replaces the placeholder: tools table (all 22),
+  install steps for .NET / netcoredbg / the tool, Claude Code + Claude Desktop config
+  snippets, macOS arm64 note, known limits (data BP adapter dep, process_write_input gap).
+  scripts/build-netcoredbg-macos-arm64.sh automates the arm64 netcoredbg build with the
+  cmake-4.x policy workaround. GitHub Actions CI workflow (.github/workflows/ci.yml):
+  Linux + macOS matrix, restore/build/test, dotnet pack on Linux + upload nupkg artifact.
+  Local `dotnet pack` succeeds — produced AspNetCoreDebuggerMcp.0.1.0-preview.nupkg.
 
 ## Decisions made
 - **Approach:** MCP server that wraps `netcoredbg` (MIT) over the Debug Adapter Protocol — chosen
@@ -45,15 +54,14 @@
   Roslyn code navigation is out of scope.
 
 ## Where we left off
-- Wave 4 done on branch `feature/MAG-39-debugger-mcp`. Linear ticket: MAG-39.
-- 22 MCP tools live. Awaiting user "go" for Wave 5 (final).
+- ALL 5 WAVES COMPLETE on branch `feature/MAG-39-debugger-mcp`. Linear ticket: MAG-39.
+- 22 MCP tools live, 44 unit tests passing, end-to-end smoke for every wave passes, NuGet
+  package builds, README done, CI defined.
+- Awaiting decision on raising the PR.
 
 ## What's next
-1. Wave 5 (needs user "go" — last wave): package as a .NET tool, netcoredbg bundling decision,
-   README, macOS setup guide, CI.
-2. After Wave 5: raise the PR.
-3. Run NETCOREDBG_PATH=~/projects/netcoredbg-src/bin/netcoredbg when launching the server until
-   bundling is sorted (Wave 5).
+1. Raise the PR (one branch, one PR, all 5 waves) — needs user confirmation.
+2. Decide whether to publish the NuGet package (and to what feed) — out of scope for the PR.
 
 ## Gotchas
 - cmake 4.x: configured with `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` for old `cmake_minimum_required`.

--- a/STATUS.md
+++ b/STATUS.md
@@ -14,6 +14,15 @@
   semantics for breakpoint_wait). 9 new MCP tools: breakpoint_set / _set_function / _remove /
   _list / _set_exception, debug_continue / _pause / _step, breakpoint_wait. 27 unit tests passing.
   End-to-end Wave 2 smoke passes: set BP, continue, hit BP, step over, remove, continue to exit.
+- WAVE 3 COMPLETE — MVP DONE: inspection + agent value-add. InspectionService translates DAP
+  threads/stackTrace/scopes/variables/evaluate/setExpression/exceptionInfo into typed records,
+  with recursive variable expansion (depth + max-children truncation) and an exception_autopsy
+  composite that returns exception chain + top frames + top-frame locals + source snippet in
+  one call. breakpoint_wait now also returns the topmost frame and a source snippet
+  (auto-context-on-stop). 6 new MCP tools: threads_list, stacktrace_get, variables_get,
+  evaluate, variables_set, exception_autopsy. 30 unit tests passing. End-to-end Wave 3 smoke
+  validates the whole MVP loop including variables_set actually mutating runtime state
+  (set x=100, evaluate confirms 100) and exception_autopsy capturing a real NRE.
 
 ## Decisions made
 - **Approach:** MCP server that wraps `netcoredbg` (MIT) over the Debug Adapter Protocol — chosen
@@ -26,14 +35,13 @@
   Roslyn code navigation is out of scope.
 
 ## Where we left off
-- Wave 2 done on branch `feature/MAG-39-debugger-mcp`. Linear ticket: MAG-39.
-- 13 MCP tools live, all unit + smoke tests green. Awaiting user "go" for Wave 3.
+- Wave 3 done on branch `feature/MAG-39-debugger-mcp`. Linear ticket: MAG-39.
+- 19 MCP tools live, MVP functionally complete. Awaiting user "go" for Wave 4.
 
 ## What's next
-1. Wave 3 (needs user "go" — MVP completes here): threads_list, stacktrace_get, variables_get
-   (recursive expansion + collection summarisation), evaluate, variables_set, exception_autopsy,
-   auto-context-on-stop.
-2. Run NETCOREDBG_PATH=~/projects/netcoredbg-src/bin/netcoredbg when launching the server until
+1. Wave 4 (needs user "go"): hang/deadlock analyzer, data/watch breakpoints, process stdin/stdout I/O.
+2. Wave 5: package as a .NET tool, netcoredbg bundling, README, macOS setup, CI.
+3. Run NETCOREDBG_PATH=~/projects/netcoredbg-src/bin/netcoredbg when launching the server until
    bundling is sorted (Wave 5).
 
 ## Gotchas

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,14 @@
 # STATUS
 
 ## What was built
-- Repo scaffolding: LICENSE (MIT), README.md, SPEC.md, .gitignore.
-- Wave 0 in progress.
+- Repo scaffolding: LICENSE (MIT), README.md, SPEC.md, .gitignore (committed + pushed, commit 6f76708).
+- netcoredbg built natively for arm64 macOS from source — binary works, runs as native arm64.
+- WAVE 0 COMPLETE: DAP launch-break test passed — netcoredbg launched a .NET 10 app, bound a
+  breakpoint, and hit it (`stopped` reason=breakpoint). No macOS permission/entitlement blocker.
+- WAVE 1 COMPLETE: C# .NET 10 MCP server building cleanly. DAP layer (framing + client +
+  request/response correlation + event dispatch). netcoredbg process lifecycle. Session state
+  machine + handshake. Four MCP tools (debug_launch / _attach / _disconnect / _state). 14 unit
+  tests passing. End-to-end smoke test passes against the real netcoredbg + a real test .NET app.
 
 ## Decisions made
 - **Approach:** MCP server that wraps `netcoredbg` (MIT) over the Debug Adapter Protocol — chosen
@@ -15,16 +21,26 @@
   Roslyn code navigation is out of scope.
 
 ## Where we left off
-- Wave 0: netcoredbg arm64 source build running (cmake + make in `~/projects/netcoredbg-src/build`).
-- Feasibility of the native arm64 build is the gate for proceeding to Wave 1.
+- Wave 1 done on branch `feature/MAG-39-debugger-mcp`. Linear ticket: MAG-39.
+- Smoke test: launch TestApp.dll with stopAtEntry → state Running → async entry-stop → state Paused
+  with lastStop reason=entry → disconnect clean. The whole MCP → DAP → ICorDebug chain works.
+- Awaiting user "go" for Wave 2 (breakpoints + execution control).
 
 ## What's next
-- Confirm the netcoredbg arm64 build succeeds and the binary runs / speaks DAP.
-- Create the Linear ticket before any Wave 1 code.
-- Wave 1: scaffold the C# MCP server + hand-rolled DAP client.
+1. Wave 2 (needs user "go"): breakpoint_set/_function/_remove/_list/_set_exception,
+   debug_continue/pause/step, breakpoint_wait.
+2. Run NETCOREDBG_PATH=~/projects/netcoredbg-src/bin/netcoredbg when launching the server until
+   bundling is sorted (Wave 5).
 
 ## Gotchas
 - cmake 4.x: configured with `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` for old `cmake_minimum_required`.
 - An x64 debugger can only debug x64 targets; a native arm64 netcoredbg is required to debug
   native arm64 .NET processes (and to support attach on Apple Silicon).
-- MIT LICENSE copyright holder is currently "magna-nz" — change to the correct person/company.
+- MIT LICENSE copyright holder is "magna-nz" (confirmed correct by user).
+- netcoredbg source + build tree live at `~/projects/netcoredbg-src` (separate from this repo);
+  how to vendor/bundle the binary is a Wave 5 decision.
+- DAP behavior to handle in Wave 1: `setBreakpoints` may respond `verified:false` initially, then
+  send an async `breakpoint` event upgrading to `verified:true` once the module loads. The DAP
+  client must track `breakpoint` events, not just the `setBreakpoints` response.
+- DAP launch flow confirmed: initialize → (response) → launch → `initialized` event →
+  setBreakpoints → configurationDone → process runs → `stopped` event.

--- a/STATUS.md
+++ b/STATUS.md
@@ -23,6 +23,16 @@
   evaluate, variables_set, exception_autopsy. 30 unit tests passing. End-to-end Wave 3 smoke
   validates the whole MVP loop including variables_set actually mutating runtime state
   (set x=100, evaluate confirms 100) and exception_autopsy capturing a real NRE.
+- WAVE 4 COMPLETE: differentiators. ThreadAnalyzer (pure classifier) + hang_analyze composite
+  that auto-pauses if running, lists threads, fetches top frames, classifies each thread's
+  blocking pattern (Monitor / WaitHandle / Semaphore / Task / Thread.Join / Sleep / async).
+  DAP `output` events buffered per session; process_read_output drains them. Data breakpoints
+  wired (registry + setDataBreakpoints), but **netcoredbg returns E_NOTIMPL (0x80004001) for
+  dataBreakpointInfo** — the tool exists and surfaces the adapter limitation cleanly; an
+  adapter that supports it would just work. 3 new MCP tools (22 total): hang_analyze,
+  breakpoint_set_data, process_read_output. 44 unit tests passing. End-to-end Wave 4 smoke
+  validates hang_analyze classifying threads and process_read_output capturing "Sum: 30".
+  Enum responses now serialize as camelCase strings (e.g. "blockedOnMonitor"), not ints.
 
 ## Decisions made
 - **Approach:** MCP server that wraps `netcoredbg` (MIT) over the Debug Adapter Protocol — chosen
@@ -35,12 +45,13 @@
   Roslyn code navigation is out of scope.
 
 ## Where we left off
-- Wave 3 done on branch `feature/MAG-39-debugger-mcp`. Linear ticket: MAG-39.
-- 19 MCP tools live, MVP functionally complete. Awaiting user "go" for Wave 4.
+- Wave 4 done on branch `feature/MAG-39-debugger-mcp`. Linear ticket: MAG-39.
+- 22 MCP tools live. Awaiting user "go" for Wave 5 (final).
 
 ## What's next
-1. Wave 4 (needs user "go"): hang/deadlock analyzer, data/watch breakpoints, process stdin/stdout I/O.
-2. Wave 5: package as a .NET tool, netcoredbg bundling, README, macOS setup, CI.
+1. Wave 5 (needs user "go" — last wave): package as a .NET tool, netcoredbg bundling decision,
+   README, macOS setup guide, CI.
+2. After Wave 5: raise the PR.
 3. Run NETCOREDBG_PATH=~/projects/netcoredbg-src/bin/netcoredbg when launching the server until
    bundling is sorted (Wave 5).
 
@@ -61,3 +72,9 @@
 - StopWaiter is Reset() synchronously inside ContinueAsync/StepAsync (before the DAP request is
   sent) so a wait registered immediately after sees a fresh TCS. Resetting on the `continued`
   event instead would race the agent.
+- netcoredbg lacks data breakpoint support (dataBreakpointInfo → E_NOTIMPL). The
+  breakpoint_set_data tool exists and works in principle; users get a clear "adapter doesn't
+  support this" error message.
+- process_write_input is NOT implemented in Wave 4. DAP launch mode owns the debuggee's stdin
+  (netcoredbg launched it); we'd need a different launch architecture (we launch the process
+  ourselves and have netcoredbg attach) to plumb stdin. Deferred — flag for a future wave.

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestMinor"
+  }
+}

--- a/scripts/build-netcoredbg-macos-arm64.sh
+++ b/scripts/build-netcoredbg-macos-arm64.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Builds netcoredbg from source for native macOS arm64 (Apple Silicon).
+#
+# Why: Samsung doesn't publish an arm64 macOS prebuilt. They flag the arm64
+# macOS build as "community supported"; it builds cleanly and works for the
+# functionality this MCP server exercises.
+#
+# Prerequisites:
+#   - Xcode Command Line Tools (`xcode-select --install`)
+#   - CMake (`brew install cmake`)
+#   - .NET 10 SDK
+#
+# Output: prints the absolute path of the built binary and the
+# NETCOREDBG_PATH export to copy into your shell.
+
+set -euo pipefail
+
+DEST="${1:-$HOME/projects/netcoredbg-src}"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "This script is for macOS only." >&2
+  exit 1
+fi
+if [[ "$(uname -m)" != "arm64" ]]; then
+  echo "This script is for Apple Silicon (arm64). On Intel macOS use Samsung's prebuilt." >&2
+  exit 1
+fi
+
+for cmd in git cmake clang make dotnet; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Required command not found: $cmd" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -d "$DEST" ]]; then
+  echo "Cloning Samsung/netcoredbg into $DEST..."
+  git clone --depth 1 https://github.com/Samsung/netcoredbg.git "$DEST"
+else
+  echo "Using existing checkout at $DEST"
+fi
+
+cd "$DEST"
+rm -rf build
+mkdir build
+cd build
+
+# -DCMAKE_POLICY_VERSION_MINIMUM=3.5 lets newer CMake accept older
+# cmake_minimum_required statements in netcoredbg's tree.
+echo "Configuring..."
+CC=clang CXX=clang++ cmake .. \
+  -DCMAKE_INSTALL_PREFIX="$PWD/../bin" \
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+
+echo "Building..."
+make -j"$(sysctl -n hw.ncpu)"
+
+echo "Installing..."
+make install
+
+BIN="$DEST/bin/netcoredbg"
+if [[ ! -x "$BIN" ]]; then
+  echo "Build appeared to succeed but no binary at $BIN" >&2
+  exit 1
+fi
+
+echo
+echo "Built: $BIN"
+echo
+echo "Add this to your shell profile (and current shell):"
+echo "    export NETCOREDBG_PATH=$BIN"

--- a/src/AspNetCoreDebuggerMcp/AspNetCoreDebuggerMcp.csproj
+++ b/src/AspNetCoreDebuggerMcp/AspNetCoreDebuggerMcp.csproj
@@ -7,7 +7,27 @@
     <Nullable>enable</Nullable>
     <RootNamespace>AspNetCoreDebuggerMcp</RootNamespace>
     <AssemblyName>AspNetCoreDebuggerMcp</AssemblyName>
+
+    <!-- .NET tool packaging -->
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>aspnetcore-debugger-mcp</ToolCommandName>
+    <PackageId>AspNetCoreDebuggerMcp</PackageId>
+    <Version>0.1.0-preview</Version>
+
+    <!-- NuGet metadata -->
+    <Authors>magna-nz</Authors>
+    <Description>MIT-licensed Model Context Protocol server that gives AI agents interactive .NET debugging by wrapping netcoredbg (Samsung) over the Debug Adapter Protocol. 22 tools across session management, breakpoints, execution, inspection, evaluation, exception analysis, hang detection, and process output.</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/magna-nz/aspnetcore-debugger-mcp</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/magna-nz/aspnetcore-debugger-mcp</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>mcp;mcp-server;debugger;dotnet;netcoredbg;dap;ai;ai-agent;debugging;breakpoints;aspnetcore</PackageTags>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />

--- a/src/AspNetCoreDebuggerMcp/AspNetCoreDebuggerMcp.csproj
+++ b/src/AspNetCoreDebuggerMcp/AspNetCoreDebuggerMcp.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>AspNetCoreDebuggerMcp</RootNamespace>
+    <AssemblyName>AspNetCoreDebuggerMcp</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="AspNetCoreDebuggerMcp.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/AspNetCoreDebuggerMcp/Breakpoints/Breakpoint.cs
+++ b/src/AspNetCoreDebuggerMcp/Breakpoints/Breakpoint.cs
@@ -1,0 +1,24 @@
+namespace AspNetCoreDebuggerMcp.Breakpoints;
+
+public sealed record LineBreakpoint(
+    string Id,
+    string SourcePath,
+    int Line,
+    string? Condition,
+    string? HitCondition,
+    string? LogMessage,
+    bool Verified,
+    int? AdapterId);
+
+public sealed record FunctionBreakpoint(
+    string Id,
+    string FunctionName,
+    string? Condition,
+    string? HitCondition,
+    bool Verified,
+    int? AdapterId);
+
+public sealed record BreakpointsSnapshot(
+    IReadOnlyList<LineBreakpoint> Line,
+    IReadOnlyList<FunctionBreakpoint> Function,
+    IReadOnlyList<string> ExceptionFilters);

--- a/src/AspNetCoreDebuggerMcp/Breakpoints/Breakpoint.cs
+++ b/src/AspNetCoreDebuggerMcp/Breakpoints/Breakpoint.cs
@@ -18,7 +18,16 @@ public sealed record FunctionBreakpoint(
     bool Verified,
     int? AdapterId);
 
+public sealed record DataBreakpoint(
+    string Id,
+    string DataId,          // DAP-issued opaque token from dataBreakpointInfo
+    string Description,     // human-readable, from the probe
+    string AccessType,      // "read" | "write" | "readWrite"
+    bool Verified,
+    int? AdapterId);
+
 public sealed record BreakpointsSnapshot(
     IReadOnlyList<LineBreakpoint> Line,
     IReadOnlyList<FunctionBreakpoint> Function,
+    IReadOnlyList<DataBreakpoint> Data,
     IReadOnlyList<string> ExceptionFilters);

--- a/src/AspNetCoreDebuggerMcp/Breakpoints/BreakpointRegistry.cs
+++ b/src/AspNetCoreDebuggerMcp/Breakpoints/BreakpointRegistry.cs
@@ -8,6 +8,7 @@ internal sealed class BreakpointRegistry
     private readonly object _gate = new();
     private readonly List<LineBreakpoint> _line = new();
     private readonly List<FunctionBreakpoint> _function = new();
+    private readonly List<DataBreakpoint> _data = new();
     private readonly HashSet<string> _exceptionFilters = new(StringComparer.OrdinalIgnoreCase);
 
     public LineBreakpoint AddLine(
@@ -34,7 +35,7 @@ internal sealed class BreakpointRegistry
     }
 
     /// Removes the breakpoint with the given id from any list it lives in.
-    /// Returns the kind removed (line / function) or null if not found.
+    /// Returns the kind removed (line / function / data) or null if not found.
     public BreakpointKind? Remove(string id)
     {
         lock (_gate)
@@ -43,7 +44,36 @@ internal sealed class BreakpointRegistry
             if (i >= 0) { _line.RemoveAt(i); return BreakpointKind.Line; }
             int j = _function.FindIndex(b => b.Id == id);
             if (j >= 0) { _function.RemoveAt(j); return BreakpointKind.Function; }
+            int k = _data.FindIndex(b => b.Id == id);
+            if (k >= 0) { _data.RemoveAt(k); return BreakpointKind.Data; }
             return null;
+        }
+    }
+
+    public DataBreakpoint AddData(string dataId, string description, string accessType)
+    {
+        var bp = new DataBreakpoint(
+            Id: NewId("dbp"),
+            DataId: dataId,
+            Description: description,
+            AccessType: accessType,
+            Verified: false,
+            AdapterId: null);
+        lock (_gate) _data.Add(bp);
+        return bp;
+    }
+
+    public IReadOnlyList<DataBreakpoint> AllData()
+    {
+        lock (_gate) return _data.ToList();
+    }
+
+    public void UpdateData(string id, bool verified, int? adapterId)
+    {
+        lock (_gate)
+        {
+            int i = _data.FindIndex(b => b.Id == id);
+            if (i >= 0) _data[i] = _data[i] with { Verified = verified, AdapterId = adapterId };
         }
     }
 
@@ -116,6 +146,7 @@ internal sealed class BreakpointRegistry
             return new BreakpointsSnapshot(
                 _line.ToList(),
                 _function.ToList(),
+                _data.ToList(),
                 _exceptionFilters.ToList());
     }
 
@@ -123,4 +154,4 @@ internal sealed class BreakpointRegistry
         => $"{prefix}-{Guid.NewGuid():N}"[..(prefix.Length + 1 + 8)];
 }
 
-internal enum BreakpointKind { Line, Function }
+internal enum BreakpointKind { Line, Function, Data }

--- a/src/AspNetCoreDebuggerMcp/Breakpoints/BreakpointRegistry.cs
+++ b/src/AspNetCoreDebuggerMcp/Breakpoints/BreakpointRegistry.cs
@@ -1,0 +1,126 @@
+namespace AspNetCoreDebuggerMcp.Breakpoints;
+
+/// In-memory store for the user's intended set of breakpoints. The DAP adapter requires
+/// a full-replacement model (setBreakpoints overwrites all BPs for a source), so we keep
+/// the authoritative intent here and re-send it on every mutation.
+internal sealed class BreakpointRegistry
+{
+    private readonly object _gate = new();
+    private readonly List<LineBreakpoint> _line = new();
+    private readonly List<FunctionBreakpoint> _function = new();
+    private readonly HashSet<string> _exceptionFilters = new(StringComparer.OrdinalIgnoreCase);
+
+    public LineBreakpoint AddLine(
+        string sourcePath, int line, string? condition, string? hitCondition, string? logMessage)
+    {
+        var bp = new LineBreakpoint(
+            Id: NewId("bp"),
+            SourcePath: sourcePath, Line: line,
+            Condition: condition, HitCondition: hitCondition, LogMessage: logMessage,
+            Verified: false, AdapterId: null);
+        lock (_gate) _line.Add(bp);
+        return bp;
+    }
+
+    public FunctionBreakpoint AddFunction(string functionName, string? condition, string? hitCondition)
+    {
+        var bp = new FunctionBreakpoint(
+            Id: NewId("fbp"),
+            FunctionName: functionName,
+            Condition: condition, HitCondition: hitCondition,
+            Verified: false, AdapterId: null);
+        lock (_gate) _function.Add(bp);
+        return bp;
+    }
+
+    /// Removes the breakpoint with the given id from any list it lives in.
+    /// Returns the kind removed (line / function) or null if not found.
+    public BreakpointKind? Remove(string id)
+    {
+        lock (_gate)
+        {
+            int i = _line.FindIndex(b => b.Id == id);
+            if (i >= 0) { _line.RemoveAt(i); return BreakpointKind.Line; }
+            int j = _function.FindIndex(b => b.Id == id);
+            if (j >= 0) { _function.RemoveAt(j); return BreakpointKind.Function; }
+            return null;
+        }
+    }
+
+    public string? GetSourcePathOf(string id)
+    {
+        lock (_gate)
+            return _line.FirstOrDefault(b => b.Id == id)?.SourcePath;
+    }
+
+    public IReadOnlyList<LineBreakpoint> ForSource(string sourcePath)
+    {
+        lock (_gate)
+            return _line
+                .Where(b => string.Equals(b.SourcePath, sourcePath, StringComparison.Ordinal))
+                .ToList();
+    }
+
+    public IReadOnlyList<FunctionBreakpoint> AllFunction()
+    {
+        lock (_gate) return _function.ToList();
+    }
+
+    /// All distinct source paths currently holding at least one line breakpoint.
+    public IReadOnlyList<string> Sources()
+    {
+        lock (_gate) return _line.Select(b => b.SourcePath).Distinct(StringComparer.Ordinal).ToList();
+    }
+
+    public void UpdateLine(string id, bool verified, int? adapterId)
+    {
+        lock (_gate)
+        {
+            int i = _line.FindIndex(b => b.Id == id);
+            if (i >= 0) _line[i] = _line[i] with { Verified = verified, AdapterId = adapterId };
+        }
+    }
+
+    public void UpdateFunction(string id, bool verified, int? adapterId)
+    {
+        lock (_gate)
+        {
+            int i = _function.FindIndex(b => b.Id == id);
+            if (i >= 0) _function[i] = _function[i] with { Verified = verified, AdapterId = adapterId };
+        }
+    }
+
+    public void UpdateLineByAdapterId(int adapterId, bool verified)
+    {
+        lock (_gate)
+        {
+            for (int i = 0; i < _line.Count; i++)
+                if (_line[i].AdapterId == adapterId)
+                    _line[i] = _line[i] with { Verified = verified };
+        }
+    }
+
+    public void SetExceptionFilters(IEnumerable<string> filters)
+    {
+        lock (_gate)
+        {
+            _exceptionFilters.Clear();
+            foreach (var f in filters)
+                if (!string.IsNullOrWhiteSpace(f)) _exceptionFilters.Add(f);
+        }
+    }
+
+    public BreakpointsSnapshot Snapshot()
+    {
+        lock (_gate)
+            return new BreakpointsSnapshot(
+                _line.ToList(),
+                _function.ToList(),
+                _exceptionFilters.ToList());
+    }
+
+    private static string NewId(string prefix)
+        => $"{prefix}-{Guid.NewGuid():N}"[..(prefix.Length + 1 + 8)];
+}
+
+internal enum BreakpointKind { Line, Function }

--- a/src/AspNetCoreDebuggerMcp/Dap/DapClient.cs
+++ b/src/AspNetCoreDebuggerMcp/Dap/DapClient.cs
@@ -1,0 +1,108 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+
+namespace AspNetCoreDebuggerMcp.Dap;
+
+/// Hand-rolled DAP client: speaks Content-Length framed JSON over a pair of streams,
+/// correlates responses to requests by `seq`, and dispatches events to subscribers.
+internal sealed class DapClient : IAsyncDisposable
+{
+    private readonly Stream _input;
+    private readonly Stream _output;
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private readonly ConcurrentDictionary<int, TaskCompletionSource<DapMessage>> _pending = new();
+    private readonly CancellationTokenSource _cts = new();
+    private int _seq;
+    private Task? _readLoop;
+
+    public event Action<DapMessage>? EventReceived;
+
+    public DapClient(Stream input, Stream output)
+    {
+        _input = input;
+        _output = output;
+    }
+
+    /// Start the background read loop. Tests can omit this and drive HandleInbound directly.
+    public void Start() => _readLoop ??= Task.Run(ReadLoopAsync);
+
+    public async Task<DapMessage> SendRequestAsync(string command, object? arguments, CancellationToken ct)
+    {
+        int seq = Interlocked.Increment(ref _seq);
+        var tcs = new TaskCompletionSource<DapMessage>(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (!_pending.TryAdd(seq, tcs))
+            throw new InvalidOperationException($"seq {seq} already in use");
+
+        var envelope = new Dictionary<string, object?>
+        {
+            ["seq"] = seq,
+            ["type"] = "request",
+            ["command"] = command,
+        };
+        if (arguments is not null) envelope["arguments"] = arguments;
+
+        var json = JsonSerializer.Serialize(envelope);
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await DapProtocol.WriteMessageAsync(_output, json, ct).ConfigureAwait(false);
+        }
+        finally { _writeLock.Release(); }
+
+        using (ct.Register(() =>
+        {
+            if (_pending.TryRemove(seq, out var t)) t.TrySetCanceled(ct);
+        }))
+        {
+            return await tcs.Task.ConfigureAwait(false);
+        }
+    }
+
+    /// Visible for tests: dispatch a received message exactly as the read loop would.
+    internal void HandleInbound(DapMessage message)
+    {
+        switch (message.Type)
+        {
+            case "response":
+                if (_pending.TryRemove(message.RequestSeq, out var tcs))
+                    tcs.TrySetResult(message);
+                break;
+            case "event":
+                EventReceived?.Invoke(message);
+                break;
+        }
+    }
+
+    private async Task ReadLoopAsync()
+    {
+        try
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                var raw = await DapProtocol.ReadMessageAsync(_input, _cts.Token).ConfigureAwait(false);
+                if (raw is null) break;
+                using var doc = JsonDocument.Parse(raw);
+                HandleInbound(DapMessage.Parse(doc.RootElement));
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception) { /* stream broke — fall through to fail pending */ }
+        finally
+        {
+            foreach (var kv in _pending)
+                kv.Value.TrySetException(new IOException("DAP connection closed"));
+            _pending.Clear();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _cts.Cancel();
+        if (_readLoop is not null)
+        {
+            try { await _readLoop.ConfigureAwait(false); } catch { }
+        }
+        _cts.Dispose();
+        _writeLock.Dispose();
+    }
+}

--- a/src/AspNetCoreDebuggerMcp/Dap/DapClient.cs
+++ b/src/AspNetCoreDebuggerMcp/Dap/DapClient.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace AspNetCoreDebuggerMcp.Dap;
 
@@ -7,6 +8,12 @@ namespace AspNetCoreDebuggerMcp.Dap;
 /// correlates responses to requests by `seq`, and dispatches events to subscribers.
 internal sealed class DapClient : IAsyncDisposable
 {
+    // netcoredbg's DAP parser rejects null values where a string is expected; omit them.
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
     private readonly Stream _input;
     private readonly Stream _output;
     private readonly SemaphoreSlim _writeLock = new(1, 1);
@@ -41,7 +48,7 @@ internal sealed class DapClient : IAsyncDisposable
         };
         if (arguments is not null) envelope["arguments"] = arguments;
 
-        var json = JsonSerializer.Serialize(envelope);
+        var json = JsonSerializer.Serialize(envelope, JsonOpts);
         await _writeLock.WaitAsync(ct).ConfigureAwait(false);
         try
         {

--- a/src/AspNetCoreDebuggerMcp/Dap/DapMessage.cs
+++ b/src/AspNetCoreDebuggerMcp/Dap/DapMessage.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+
+namespace AspNetCoreDebuggerMcp.Dap;
+
+/// A parsed DAP protocol message (response or event).
+internal sealed class DapMessage
+{
+    public int Seq { get; init; }
+    public string Type { get; init; } = "";   // "response" | "event" | "request"
+
+    // response-only
+    public int RequestSeq { get; init; }
+    public bool Success { get; init; }
+    public string? Command { get; init; }
+    public string? Message { get; init; }
+
+    // event-only
+    public string? Event { get; init; }
+
+    // payload (response.body or event.body)
+    public JsonElement? Body { get; init; }
+
+    public static DapMessage Parse(JsonElement root)
+    {
+        var type = root.TryGetProperty("type", out var t) ? (t.GetString() ?? "") : "";
+        return new DapMessage
+        {
+            Seq = root.TryGetProperty("seq", out var s) ? s.GetInt32() : 0,
+            Type = type,
+            RequestSeq = root.TryGetProperty("request_seq", out var rs) ? rs.GetInt32() : 0,
+            Success = root.TryGetProperty("success", out var su) && su.ValueKind == JsonValueKind.True,
+            Command = root.TryGetProperty("command", out var c) ? c.GetString() : null,
+            Message = root.TryGetProperty("message", out var m) ? m.GetString() : null,
+            Event = root.TryGetProperty("event", out var e) ? e.GetString() : null,
+            // Clone so the element remains valid after the source JsonDocument is disposed.
+            Body = root.TryGetProperty("body", out var b) ? b.Clone() : null,
+        };
+    }
+}

--- a/src/AspNetCoreDebuggerMcp/Dap/DapProtocol.cs
+++ b/src/AspNetCoreDebuggerMcp/Dap/DapProtocol.cs
@@ -1,0 +1,55 @@
+using System.Text;
+
+namespace AspNetCoreDebuggerMcp.Dap;
+
+/// DAP message framing: each message is "Content-Length: N\r\n\r\n" + N bytes of UTF-8 JSON.
+internal static class DapProtocol
+{
+    public static async Task WriteMessageAsync(Stream stream, string json, CancellationToken ct)
+    {
+        var payload = Encoding.UTF8.GetBytes(json);
+        var header = Encoding.ASCII.GetBytes($"Content-Length: {payload.Length}\r\n\r\n");
+        await stream.WriteAsync(header, ct).ConfigureAwait(false);
+        await stream.WriteAsync(payload, ct).ConfigureAwait(false);
+        await stream.FlushAsync(ct).ConfigureAwait(false);
+    }
+
+    /// Reads one framed message. Returns null on clean end-of-stream.
+    public static async Task<string?> ReadMessageAsync(Stream stream, CancellationToken ct)
+    {
+        var header = new List<byte>(64);
+        var one = new byte[1];
+        while (true)
+        {
+            int n = await stream.ReadAsync(one.AsMemory(0, 1), ct).ConfigureAwait(false);
+            if (n == 0) return null;
+            header.Add(one[0]);
+            int c = header.Count;
+            if (c >= 4 && header[c - 4] == (byte)'\r' && header[c - 3] == (byte)'\n'
+                       && header[c - 2] == (byte)'\r' && header[c - 1] == (byte)'\n')
+                break;
+        }
+
+        int length = ParseContentLength(Encoding.ASCII.GetString(header.ToArray()));
+        var body = new byte[length];
+        int read = 0;
+        while (read < length)
+        {
+            int n = await stream.ReadAsync(body.AsMemory(read, length - read), ct).ConfigureAwait(false);
+            if (n == 0) throw new EndOfStreamException("DAP body truncated");
+            read += n;
+        }
+        return Encoding.UTF8.GetString(body);
+    }
+
+    private static int ParseContentLength(string header)
+    {
+        foreach (var line in header.Split("\r\n", StringSplitOptions.RemoveEmptyEntries))
+        {
+            const string key = "Content-Length:";
+            if (line.StartsWith(key, StringComparison.OrdinalIgnoreCase))
+                return int.Parse(line[key.Length..].Trim());
+        }
+        throw new FormatException("DAP message missing Content-Length header");
+    }
+}

--- a/src/AspNetCoreDebuggerMcp/Debugging/DebugException.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/DebugException.cs
@@ -1,0 +1,7 @@
+namespace AspNetCoreDebuggerMcp.Debugging;
+
+public sealed class DebugException : Exception
+{
+    public DebugException(string message) : base(message) { }
+    public DebugException(string message, Exception inner) : base(message, inner) { }
+}

--- a/src/AspNetCoreDebuggerMcp/Debugging/DebugSession.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/DebugSession.cs
@@ -1,0 +1,199 @@
+using System.Text.Json;
+using AspNetCoreDebuggerMcp.Dap;
+
+namespace AspNetCoreDebuggerMcp.Debugging;
+
+/// One active debug session: owns the netcoredbg process and the DAP client,
+/// runs the launch/attach handshake, and translates DAP events into state transitions.
+internal sealed class DebugSession : IAsyncDisposable
+{
+    private readonly NetcoredbgProcess _process;
+    private readonly DapClient _client;
+    private readonly SessionStateMachine _stateMachine = new();
+    private readonly TaskCompletionSource _initializedTcs =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly object _gate = new();
+    private int? _processId;
+    private StopInfo? _lastStop;
+
+    public SessionState State => _stateMachine.State;
+    public int? ProcessId { get { lock (_gate) return _processId; } }
+    public StopInfo? LastStop { get { lock (_gate) return _lastStop; } }
+
+    public SessionSnapshot Snapshot() => new(State.ToString(), ProcessId, LastStop);
+
+    private DebugSession(NetcoredbgProcess process, DapClient client)
+    {
+        _process = process;
+        _client = client;
+        _client.EventReceived += OnDapEvent;
+    }
+
+    public static async Task<DebugSession> LaunchAsync(
+        string netcoredbgPath,
+        string program,
+        string[]? args,
+        string? cwd,
+        bool stopAtEntry,
+        CancellationToken ct)
+    {
+        var session = StartAdapter(netcoredbgPath);
+        try
+        {
+            await session.HandshakeAsync(
+                isLaunch: true,
+                startArgs: BuildLaunchArgs(program, args, cwd, stopAtEntry),
+                ct).ConfigureAwait(false);
+            return session;
+        }
+        catch
+        {
+            await session.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    public static async Task<DebugSession> AttachAsync(
+        string netcoredbgPath,
+        int processId,
+        CancellationToken ct)
+    {
+        var session = StartAdapter(netcoredbgPath);
+        try
+        {
+            await session.HandshakeAsync(
+                isLaunch: false,
+                startArgs: new Dictionary<string, object?> { ["processId"] = processId },
+                ct).ConfigureAwait(false);
+            return session;
+        }
+        catch
+        {
+            await session.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private static DebugSession StartAdapter(string netcoredbgPath)
+    {
+        var process = NetcoredbgProcess.Start(netcoredbgPath);
+        var client = new DapClient(process.Input, process.Output);
+        client.Start();
+        return new DebugSession(process, client);
+    }
+
+    private static Dictionary<string, object?> BuildLaunchArgs(
+        string program, string[]? args, string? cwd, bool stopAtEntry)
+    {
+        var d = new Dictionary<string, object?>
+        {
+            ["program"] = program,
+            ["stopAtEntry"] = stopAtEntry,
+            ["justMyCode"] = true,
+        };
+        if (args is { Length: > 0 }) d["args"] = args;
+        if (!string.IsNullOrEmpty(cwd)) d["cwd"] = cwd;
+        return d;
+    }
+
+    private async Task HandshakeAsync(
+        bool isLaunch, Dictionary<string, object?> startArgs, CancellationToken ct)
+    {
+        var initialize = await _client.SendRequestAsync("initialize", new
+        {
+            clientID = "aspnetcore-debugger-mcp",
+            adapterID = "coreclr",
+            linesStartAt1 = true,
+            columnsStartAt1 = true,
+            pathFormat = "path",
+        }, ct).ConfigureAwait(false);
+        if (!initialize.Success)
+            throw new DebugException($"initialize failed: {initialize.Message ?? "unknown"}");
+
+        // Send launch/attach now; its response may not arrive until after configurationDone.
+        var startTask = _client.SendRequestAsync(isLaunch ? "launch" : "attach", startArgs, ct);
+
+        await _initializedTcs.Task.WaitAsync(ct).ConfigureAwait(false);
+        _stateMachine.Transition(SessionState.Configuring);
+
+        var configDone = await _client.SendRequestAsync("configurationDone", null, ct).ConfigureAwait(false);
+        if (!configDone.Success)
+            throw new DebugException($"configurationDone failed: {configDone.Message ?? "unknown"}");
+
+        var start = await startTask.ConfigureAwait(false);
+        if (!start.Success)
+        {
+            var op = isLaunch ? "launch" : "attach";
+            throw new DebugException($"{op} failed: {start.Message ?? "unknown"}");
+        }
+
+        _stateMachine.Transition(SessionState.Running);
+    }
+
+    public async Task DisconnectAsync(CancellationToken ct)
+    {
+        try
+        {
+            await _client.SendRequestAsync("disconnect", new { terminateDebuggee = true }, ct)
+                .ConfigureAwait(false);
+        }
+        catch
+        {
+            // Adapter may already be down — best-effort.
+        }
+        _stateMachine.OnTerminated();
+    }
+
+    private void OnDapEvent(DapMessage e)
+    {
+        switch (e.Event)
+        {
+            case "initialized":
+                _initializedTcs.TrySetResult();
+                break;
+            case "stopped":
+                HandleStopped(e);
+                break;
+            case "continued":
+                _stateMachine.OnContinued();
+                break;
+            case "process":
+                if (e.Body is { } body
+                    && body.TryGetProperty("systemProcessId", out var pid)
+                    && pid.ValueKind == JsonValueKind.Number)
+                {
+                    lock (_gate) _processId = pid.GetInt32();
+                }
+                break;
+            case "terminated":
+            case "exited":
+                _stateMachine.OnTerminated();
+                break;
+        }
+    }
+
+    private void HandleStopped(DapMessage e)
+    {
+        var reason = "unknown";
+        int? threadId = null;
+        string? description = null;
+        if (e.Body is { } body)
+        {
+            if (body.TryGetProperty("reason", out var r) && r.ValueKind == JsonValueKind.String)
+                reason = r.GetString() ?? reason;
+            if (body.TryGetProperty("threadId", out var t) && t.ValueKind == JsonValueKind.Number)
+                threadId = t.GetInt32();
+            if (body.TryGetProperty("description", out var d) && d.ValueKind == JsonValueKind.String)
+                description = d.GetString();
+        }
+        lock (_gate) _lastStop = new StopInfo(reason, threadId, description);
+        _stateMachine.OnStopped();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client.EventReceived -= OnDapEvent;
+        await _client.DisposeAsync().ConfigureAwait(false);
+        await _process.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/src/AspNetCoreDebuggerMcp/Debugging/DebugSession.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/DebugSession.cs
@@ -1,6 +1,8 @@
+using System.Collections.Concurrent;
 using System.Text.Json;
 using AspNetCoreDebuggerMcp.Breakpoints;
 using AspNetCoreDebuggerMcp.Dap;
+using AspNetCoreDebuggerMcp.Diagnostics;
 using AspNetCoreDebuggerMcp.Inspection;
 
 namespace AspNetCoreDebuggerMcp.Debugging;
@@ -16,6 +18,7 @@ internal sealed class DebugSession : IAsyncDisposable
     private readonly StopWaiter _stopWaiter = new();
     private readonly BreakpointRegistry _breakpoints = new();
     private readonly InspectionService _inspector;
+    private readonly ConcurrentQueue<OutputLine> _outputBuffer = new();
     private readonly TaskCompletionSource _initializedTcs =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly object _gate = new();
@@ -258,9 +261,121 @@ internal sealed class DebugSession : IAsyncDisposable
             case BreakpointKind.Function:
                 await SyncFunctionsAsync(ct).ConfigureAwait(false);
                 return true;
+            case BreakpointKind.Data:
+                await SyncDataBreakpointsAsync(ct).ConfigureAwait(false);
+                return true;
             default:
                 return false;
         }
+    }
+
+    public async Task<DataBreakpoint> AddDataBreakpointAsync(
+        int variablesReference, string name, string accessType, CancellationToken ct)
+    {
+        var probe = await _client.SendRequestAsync("dataBreakpointInfo",
+            new { variablesReference, name }, ct).ConfigureAwait(false);
+        if (!probe.Success)
+            throw new DebugException($"dataBreakpointInfo failed: {probe.Message ?? "unknown"}");
+
+        string? dataId = null;
+        string? description = name;
+        if (probe.Body is { } body)
+        {
+            if (body.TryGetProperty("dataId", out var didEl) && didEl.ValueKind == JsonValueKind.String)
+                dataId = didEl.GetString();
+            if (body.TryGetProperty("description", out var d) && d.ValueKind == JsonValueKind.String)
+                description = d.GetString();
+        }
+        if (string.IsNullOrEmpty(dataId))
+            throw new DebugException(
+                $"Cannot set a data breakpoint on '{name}': adapter returned no dataId" +
+                (description != name ? $" ({description})" : ""));
+
+        var bp = _breakpoints.AddData(dataId, description ?? name, accessType);
+        await SyncDataBreakpointsAsync(ct).ConfigureAwait(false);
+        return _breakpoints.AllData().First(b => b.Id == bp.Id);
+    }
+
+    private async Task SyncDataBreakpointsAsync(CancellationToken ct)
+    {
+        var data = _breakpoints.AllData();
+        var args = new
+        {
+            breakpoints = data.Select(b => new
+            {
+                dataId = b.DataId,
+                accessType = b.AccessType,
+            }).ToArray(),
+        };
+        var resp = await _client.SendRequestAsync("setDataBreakpoints", args, ct).ConfigureAwait(false);
+        if (!resp.Success)
+            throw new DebugException($"setDataBreakpoints failed: {resp.Message ?? "unknown"}");
+
+        if (resp.Body is { } body && body.TryGetProperty("breakpoints", out var arr)
+            && arr.ValueKind == JsonValueKind.Array)
+        {
+            int i = 0;
+            foreach (var elem in arr.EnumerateArray())
+            {
+                if (i >= data.Count) break;
+                var verified = elem.TryGetProperty("verified", out var v) && v.ValueKind == JsonValueKind.True;
+                int? adapterId =
+                    elem.TryGetProperty("id", out var idEl) && idEl.ValueKind == JsonValueKind.Number
+                        ? idEl.GetInt32() : null;
+                _breakpoints.UpdateData(data[i].Id, verified, adapterId);
+                i++;
+            }
+        }
+    }
+
+    // ---- output buffer + hang analysis ----------------------------------------------
+
+    public IReadOnlyList<OutputLine> DrainOutput(string? category = null, int? maxLines = null)
+    {
+        var collected = new List<OutputLine>();
+        while (_outputBuffer.TryDequeue(out var line))
+        {
+            if (category is null || string.Equals(line.Category, category, StringComparison.OrdinalIgnoreCase))
+                collected.Add(line);
+            if (maxLines is int m && collected.Count >= m) break;
+        }
+        return collected;
+    }
+
+    public async Task<HangAnalysis> HangAnalyzeAsync(int topFramesPerThread, CancellationToken ct)
+    {
+        if (State == SessionState.Running)
+        {
+            // Pause any thread so we can inspect. DAP threads is callable while running.
+            var liveThreads = await ListThreadsAsync(ct).ConfigureAwait(false);
+            if (liveThreads.Count == 0)
+                throw new DebugException("No threads available to pause for hang analysis.");
+            _stopWaiter.Reset();
+            try { await PauseAsync(liveThreads[0].Id, ct).ConfigureAwait(false); }
+            catch (Exception ex) { throw new DebugException($"hang_analyze: pause failed: {ex.Message}", ex); }
+            try
+            {
+                using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                linked.CancelAfter(TimeSpan.FromSeconds(5));
+                await _stopWaiter.WaitAsync(linked.Token).ConfigureAwait(false);
+            }
+            catch { /* may not stop within timeout; analyze what we can */ }
+        }
+
+        var threads = await ListThreadsAsync(ct).ConfigureAwait(false);
+        var infos = new List<ThreadHangInfo>(threads.Count);
+        foreach (var t in threads)
+        {
+            IReadOnlyList<string> names = Array.Empty<string>();
+            try
+            {
+                var frames = await GetStackTraceAsync(t.Id, 0, topFramesPerThread, ct).ConfigureAwait(false);
+                names = frames.Select(f => f.Name).ToList();
+            }
+            catch { /* if a single thread fails, keep going */ }
+            infos.Add(new ThreadHangInfo(t.Id, t.Name, ThreadAnalyzer.Classify(names), names));
+        }
+        return ThreadAnalyzer.Analyze(infos);
     }
 
     public async Task SetExceptionFiltersAsync(IEnumerable<string> filters, CancellationToken ct)
@@ -355,6 +470,10 @@ internal sealed class DebugSession : IAsyncDisposable
                 _stateMachine.OnContinued();
                 break;
 
+            case "output":
+                HandleOutput(e);
+                break;
+
             case "process":
                 if (e.Body is { } p
                     && p.TryGetProperty("systemProcessId", out var pid)
@@ -394,6 +513,17 @@ internal sealed class DebugSession : IAsyncDisposable
         lock (_gate) _lastStop = info;
         _stateMachine.OnStopped();
         _stopWaiter.SetStop(info);
+    }
+
+    private void HandleOutput(DapMessage e)
+    {
+        if (e.Body is not { } body) return;
+        var category = body.TryGetProperty("category", out var c) && c.ValueKind == JsonValueKind.String
+            ? c.GetString() ?? "stdout" : "stdout";
+        var output = body.TryGetProperty("output", out var o) && o.ValueKind == JsonValueKind.String
+            ? o.GetString() ?? "" : "";
+        if (output.Length == 0) return;
+        _outputBuffer.Enqueue(new OutputLine(category, output, DateTimeOffset.UtcNow));
     }
 
     private void HandleBreakpointEvent(DapMessage e)

--- a/src/AspNetCoreDebuggerMcp/Debugging/DebugSession.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/DebugSession.cs
@@ -1,15 +1,19 @@
 using System.Text.Json;
+using AspNetCoreDebuggerMcp.Breakpoints;
 using AspNetCoreDebuggerMcp.Dap;
 
 namespace AspNetCoreDebuggerMcp.Debugging;
 
 /// One active debug session: owns the netcoredbg process and the DAP client,
-/// runs the launch/attach handshake, and translates DAP events into state transitions.
+/// runs the launch/attach handshake, manages breakpoints, drives execution control,
+/// and translates DAP events into state transitions.
 internal sealed class DebugSession : IAsyncDisposable
 {
     private readonly NetcoredbgProcess _process;
     private readonly DapClient _client;
     private readonly SessionStateMachine _stateMachine = new();
+    private readonly StopWaiter _stopWaiter = new();
+    private readonly BreakpointRegistry _breakpoints = new();
     private readonly TaskCompletionSource _initializedTcs =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly object _gate = new();
@@ -21,6 +25,7 @@ internal sealed class DebugSession : IAsyncDisposable
     public StopInfo? LastStop { get { lock (_gate) return _lastStop; } }
 
     public SessionSnapshot Snapshot() => new(State.ToString(), ProcessId, LastStop);
+    public BreakpointsSnapshot BreakpointsSnapshot() => _breakpoints.Snapshot();
 
     private DebugSession(NetcoredbgProcess process, DapClient client)
     {
@@ -29,12 +34,10 @@ internal sealed class DebugSession : IAsyncDisposable
         _client.EventReceived += OnDapEvent;
     }
 
+    // ---- session lifecycle ----------------------------------------------------------
+
     public static async Task<DebugSession> LaunchAsync(
-        string netcoredbgPath,
-        string program,
-        string[]? args,
-        string? cwd,
-        bool stopAtEntry,
+        string netcoredbgPath, string program, string[]? args, string? cwd, bool stopAtEntry,
         CancellationToken ct)
     {
         var session = StartAdapter(netcoredbgPath);
@@ -42,8 +45,7 @@ internal sealed class DebugSession : IAsyncDisposable
         {
             await session.HandshakeAsync(
                 isLaunch: true,
-                startArgs: BuildLaunchArgs(program, args, cwd, stopAtEntry),
-                ct).ConfigureAwait(false);
+                startArgs: BuildLaunchArgs(program, args, cwd, stopAtEntry), ct).ConfigureAwait(false);
             return session;
         }
         catch
@@ -54,17 +56,15 @@ internal sealed class DebugSession : IAsyncDisposable
     }
 
     public static async Task<DebugSession> AttachAsync(
-        string netcoredbgPath,
-        int processId,
-        CancellationToken ct)
+        string netcoredbgPath, int processId, CancellationToken ct)
     {
         var session = StartAdapter(netcoredbgPath);
         try
         {
             await session.HandshakeAsync(
                 isLaunch: false,
-                startArgs: new Dictionary<string, object?> { ["processId"] = processId },
-                ct).ConfigureAwait(false);
+                startArgs: new Dictionary<string, object?> { ["processId"] = processId }, ct)
+                .ConfigureAwait(false);
             return session;
         }
         catch
@@ -110,7 +110,6 @@ internal sealed class DebugSession : IAsyncDisposable
         if (!initialize.Success)
             throw new DebugException($"initialize failed: {initialize.Message ?? "unknown"}");
 
-        // Send launch/attach now; its response may not arrive until after configurationDone.
         var startTask = _client.SendRequestAsync(isLaunch ? "launch" : "attach", startArgs, ct);
 
         await _initializedTcs.Task.WaitAsync(ct).ConfigureAwait(false);
@@ -139,10 +138,177 @@ internal sealed class DebugSession : IAsyncDisposable
         }
         catch
         {
-            // Adapter may already be down — best-effort.
+            // adapter may already be down; best-effort
         }
         _stateMachine.OnTerminated();
+        _stopWaiter.Terminate();
     }
+
+    // ---- execution control ----------------------------------------------------------
+
+    public async Task ContinueAsync(int? threadId, CancellationToken ct)
+    {
+        var tid = ResolveThreadId(threadId);
+        _stopWaiter.Reset();
+        var resp = await _client.SendRequestAsync("continue",
+            new Dictionary<string, object?> { ["threadId"] = tid }, ct).ConfigureAwait(false);
+        if (!resp.Success)
+            throw new DebugException($"continue failed: {resp.Message ?? "unknown"}");
+    }
+
+    public async Task PauseAsync(int? threadId, CancellationToken ct)
+    {
+        var tid = ResolveThreadId(threadId);
+        var resp = await _client.SendRequestAsync("pause",
+            new Dictionary<string, object?> { ["threadId"] = tid }, ct).ConfigureAwait(false);
+        if (!resp.Success)
+            throw new DebugException($"pause failed: {resp.Message ?? "unknown"}");
+    }
+
+    public async Task StepAsync(string kind, int? threadId, CancellationToken ct)
+    {
+        var dapCommand = kind switch
+        {
+            "in"   => "stepIn",
+            "over" => "next",
+            "out"  => "stepOut",
+            _ => throw new DebugException($"Unknown step kind '{kind}'. Use one of: in, over, out."),
+        };
+        var tid = ResolveThreadId(threadId);
+        _stopWaiter.Reset();
+        var resp = await _client.SendRequestAsync(dapCommand,
+            new Dictionary<string, object?> { ["threadId"] = tid }, ct).ConfigureAwait(false);
+        if (!resp.Success)
+            throw new DebugException($"{dapCommand} failed: {resp.Message ?? "unknown"}");
+    }
+
+    public async Task<StopInfo> WaitForStopAsync(TimeSpan timeout, CancellationToken ct)
+    {
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        linked.CancelAfter(timeout);
+        return await _stopWaiter.WaitAsync(linked.Token).ConfigureAwait(false);
+    }
+
+    private int ResolveThreadId(int? threadId)
+    {
+        if (threadId is int id) return id;
+        var stop = LastStop;
+        if (stop?.ThreadId is int known) return known;
+        throw new DebugException(
+            "No current thread known. Pass threadId explicitly, or hit a breakpoint first.");
+    }
+
+    // ---- breakpoints ----------------------------------------------------------------
+
+    public async Task<LineBreakpoint> AddLineBreakpointAsync(
+        string sourcePath, int line, string? condition, string? hitCondition, string? logMessage,
+        CancellationToken ct)
+    {
+        var bp = _breakpoints.AddLine(sourcePath, line, condition, hitCondition, logMessage);
+        await SyncSourceAsync(sourcePath, ct).ConfigureAwait(false);
+        return _breakpoints.ForSource(sourcePath).First(b => b.Id == bp.Id);
+    }
+
+    public async Task<FunctionBreakpoint> AddFunctionBreakpointAsync(
+        string functionName, string? condition, string? hitCondition, CancellationToken ct)
+    {
+        var bp = _breakpoints.AddFunction(functionName, condition, hitCondition);
+        await SyncFunctionsAsync(ct).ConfigureAwait(false);
+        return _breakpoints.AllFunction().First(f => f.Id == bp.Id);
+    }
+
+    public async Task<bool> RemoveBreakpointAsync(string id, CancellationToken ct)
+    {
+        var sourcePath = _breakpoints.GetSourcePathOf(id);
+        var kind = _breakpoints.Remove(id);
+        switch (kind)
+        {
+            case BreakpointKind.Line when sourcePath is not null:
+                await SyncSourceAsync(sourcePath, ct).ConfigureAwait(false);
+                return true;
+            case BreakpointKind.Function:
+                await SyncFunctionsAsync(ct).ConfigureAwait(false);
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public async Task SetExceptionFiltersAsync(IEnumerable<string> filters, CancellationToken ct)
+    {
+        _breakpoints.SetExceptionFilters(filters);
+        var current = _breakpoints.Snapshot().ExceptionFilters.ToArray();
+        var resp = await _client.SendRequestAsync("setExceptionBreakpoints",
+            new { filters = current }, ct).ConfigureAwait(false);
+        if (!resp.Success)
+            throw new DebugException($"setExceptionBreakpoints failed: {resp.Message ?? "unknown"}");
+    }
+
+    private async Task SyncSourceAsync(string sourcePath, CancellationToken ct)
+    {
+        var bps = _breakpoints.ForSource(sourcePath);
+        var args = new
+        {
+            source = new { path = sourcePath, name = Path.GetFileName(sourcePath) },
+            breakpoints = bps.Select(b => new
+            {
+                line = b.Line,
+                condition = b.Condition,
+                hitCondition = b.HitCondition,
+                logMessage = b.LogMessage,
+            }).ToArray(),
+            lines = bps.Select(b => b.Line).ToArray(),
+        };
+        var resp = await _client.SendRequestAsync("setBreakpoints", args, ct).ConfigureAwait(false);
+        if (!resp.Success)
+            throw new DebugException($"setBreakpoints failed: {resp.Message ?? "unknown"}");
+
+        ApplySetBreakpointsResponse(resp, bps, isLine: true);
+    }
+
+    private async Task SyncFunctionsAsync(CancellationToken ct)
+    {
+        var fns = _breakpoints.AllFunction();
+        var args = new
+        {
+            breakpoints = fns.Select(f => new
+            {
+                name = f.FunctionName,
+                condition = f.Condition,
+                hitCondition = f.HitCondition,
+            }).ToArray(),
+        };
+        var resp = await _client.SendRequestAsync("setFunctionBreakpoints", args, ct).ConfigureAwait(false);
+        if (!resp.Success)
+            throw new DebugException($"setFunctionBreakpoints failed: {resp.Message ?? "unknown"}");
+
+        ApplySetBreakpointsResponse(resp, fns, isLine: false);
+    }
+
+    private void ApplySetBreakpointsResponse<T>(DapMessage resp, IReadOnlyList<T> registryBps, bool isLine)
+    {
+        if (resp.Body is not { } body) return;
+        if (!body.TryGetProperty("breakpoints", out var arr) || arr.ValueKind != JsonValueKind.Array) return;
+
+        int i = 0;
+        foreach (var elem in arr.EnumerateArray())
+        {
+            if (i >= registryBps.Count) break;
+            var verified = elem.TryGetProperty("verified", out var v) && v.ValueKind == JsonValueKind.True;
+            int? adapterId =
+                elem.TryGetProperty("id", out var idEl) && idEl.ValueKind == JsonValueKind.Number
+                    ? idEl.GetInt32() : null;
+
+            if (isLine && registryBps[i] is LineBreakpoint lb)
+                _breakpoints.UpdateLine(lb.Id, verified, adapterId);
+            else if (!isLine && registryBps[i] is FunctionBreakpoint fb)
+                _breakpoints.UpdateFunction(fb.Id, verified, adapterId);
+
+            i++;
+        }
+    }
+
+    // ---- DAP event handling ---------------------------------------------------------
 
     private void OnDapEvent(DapMessage e)
     {
@@ -151,23 +317,32 @@ internal sealed class DebugSession : IAsyncDisposable
             case "initialized":
                 _initializedTcs.TrySetResult();
                 break;
+
             case "stopped":
                 HandleStopped(e);
                 break;
+
             case "continued":
                 _stateMachine.OnContinued();
                 break;
+
             case "process":
-                if (e.Body is { } body
-                    && body.TryGetProperty("systemProcessId", out var pid)
+                if (e.Body is { } p
+                    && p.TryGetProperty("systemProcessId", out var pid)
                     && pid.ValueKind == JsonValueKind.Number)
                 {
                     lock (_gate) _processId = pid.GetInt32();
                 }
                 break;
+
+            case "breakpoint":
+                HandleBreakpointEvent(e);
+                break;
+
             case "terminated":
             case "exited":
                 _stateMachine.OnTerminated();
+                _stopWaiter.Terminate();
                 break;
         }
     }
@@ -186,13 +361,27 @@ internal sealed class DebugSession : IAsyncDisposable
             if (body.TryGetProperty("description", out var d) && d.ValueKind == JsonValueKind.String)
                 description = d.GetString();
         }
-        lock (_gate) _lastStop = new StopInfo(reason, threadId, description);
+        var info = new StopInfo(reason, threadId, description);
+        lock (_gate) _lastStop = info;
         _stateMachine.OnStopped();
+        _stopWaiter.SetStop(info);
+    }
+
+    private void HandleBreakpointEvent(DapMessage e)
+    {
+        if (e.Body is not { } body) return;
+        if (!body.TryGetProperty("breakpoint", out var bp)) return;
+        if (!bp.TryGetProperty("id", out var idEl) || idEl.ValueKind != JsonValueKind.Number) return;
+
+        var adapterId = idEl.GetInt32();
+        var verified = bp.TryGetProperty("verified", out var v) && v.ValueKind == JsonValueKind.True;
+        _breakpoints.UpdateLineByAdapterId(adapterId, verified);
     }
 
     public async ValueTask DisposeAsync()
     {
         _client.EventReceived -= OnDapEvent;
+        _stopWaiter.Terminate();
         await _client.DisposeAsync().ConfigureAwait(false);
         await _process.DisposeAsync().ConfigureAwait(false);
     }

--- a/src/AspNetCoreDebuggerMcp/Debugging/DebugSession.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/DebugSession.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using AspNetCoreDebuggerMcp.Breakpoints;
 using AspNetCoreDebuggerMcp.Dap;
+using AspNetCoreDebuggerMcp.Inspection;
 
 namespace AspNetCoreDebuggerMcp.Debugging;
 
@@ -14,6 +15,7 @@ internal sealed class DebugSession : IAsyncDisposable
     private readonly SessionStateMachine _stateMachine = new();
     private readonly StopWaiter _stopWaiter = new();
     private readonly BreakpointRegistry _breakpoints = new();
+    private readonly InspectionService _inspector;
     private readonly TaskCompletionSource _initializedTcs =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly object _gate = new();
@@ -31,8 +33,35 @@ internal sealed class DebugSession : IAsyncDisposable
     {
         _process = process;
         _client = client;
+        _inspector = new InspectionService(client);
         _client.EventReceived += OnDapEvent;
     }
+
+    // ---- inspection (delegated to InspectionService) ---------------------------------
+
+    public Task<IReadOnlyList<ThreadInfo>> ListThreadsAsync(CancellationToken ct)
+        => _inspector.ListThreadsAsync(ct);
+
+    public Task<IReadOnlyList<StackFrame>> GetStackTraceAsync(
+        int threadId, int? startFrame, int? levels, CancellationToken ct)
+        => _inspector.GetStackTraceAsync(threadId, startFrame, levels, ct);
+
+    public Task<StackFrame?> GetTopFrameAsync(int threadId, CancellationToken ct)
+        => _inspector.GetTopFrameAsync(threadId, ct);
+
+    public Task<IReadOnlyList<ScopeWithVariables>> GetScopesAsync(
+        int frameId, int depth, int maxChildren, CancellationToken ct)
+        => _inspector.GetScopesAsync(frameId, depth, maxChildren, ct);
+
+    public Task<EvaluateResult> EvaluateAsync(string expression, int? frameId, CancellationToken ct)
+        => _inspector.EvaluateAsync(expression, frameId, ct);
+
+    public Task<EvaluateResult> SetExpressionAsync(
+        string expression, string value, int? frameId, CancellationToken ct)
+        => _inspector.SetExpressionAsync(expression, value, frameId, ct);
+
+    public Task<ExceptionAutopsy> AutopsyAsync(int threadId, int topFrameCount, CancellationToken ct)
+        => _inspector.AutopsyAsync(threadId, topFrameCount, ct);
 
     // ---- session lifecycle ----------------------------------------------------------
 

--- a/src/AspNetCoreDebuggerMcp/Debugging/DebugSession.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/DebugSession.cs
@@ -46,8 +46,8 @@ internal sealed class DebugSession : IAsyncDisposable
         => _inspector.ListThreadsAsync(ct);
 
     public Task<IReadOnlyList<StackFrame>> GetStackTraceAsync(
-        int threadId, int? startFrame, int? levels, CancellationToken ct)
-        => _inspector.GetStackTraceAsync(threadId, startFrame, levels, ct);
+        int threadId, int? startFrame, int? levels, bool raw, CancellationToken ct)
+        => _inspector.GetStackTraceAsync(threadId, startFrame, levels, raw, ct);
 
     public Task<StackFrame?> GetTopFrameAsync(int threadId, CancellationToken ct)
         => _inspector.GetTopFrameAsync(threadId, ct);
@@ -369,7 +369,7 @@ internal sealed class DebugSession : IAsyncDisposable
             IReadOnlyList<string> names = Array.Empty<string>();
             try
             {
-                var frames = await GetStackTraceAsync(t.Id, 0, topFramesPerThread, ct).ConfigureAwait(false);
+                var frames = await GetStackTraceAsync(t.Id, 0, topFramesPerThread, raw: false, ct).ConfigureAwait(false);
                 names = frames.Select(f => f.Name).ToList();
             }
             catch { /* if a single thread fails, keep going */ }

--- a/src/AspNetCoreDebuggerMcp/Debugging/DebugSessionManager.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/DebugSessionManager.cs
@@ -1,4 +1,5 @@
 using AspNetCoreDebuggerMcp.Breakpoints;
+using AspNetCoreDebuggerMcp.Diagnostics;
 using AspNetCoreDebuggerMcp.Inspection;
 
 namespace AspNetCoreDebuggerMcp.Debugging;
@@ -144,6 +145,16 @@ public sealed class DebugSessionManager : IAsyncDisposable
         return s.AutopsyAsync(ResolveThreadIdOrThrow(threadId), topFrameCount, ct);
     }
 
+    public Task<DataBreakpoint> AddDataBreakpointAsync(
+        int variablesReference, string name, string accessType, CancellationToken ct)
+        => RequireActiveSession().AddDataBreakpointAsync(variablesReference, name, accessType, ct);
+
+    public Task<HangAnalysis> HangAnalyzeAsync(int topFramesPerThread, CancellationToken ct)
+        => RequireActiveSession().HangAnalyzeAsync(topFramesPerThread, ct);
+
+    public IReadOnlyList<OutputLine> DrainOutput(string? category, int? maxLines)
+        => _session?.DrainOutput(category, maxLines) ?? Array.Empty<OutputLine>();
+
     private int ResolveThreadIdOrThrow(int? threadId)
     {
         if (threadId is int id) return id;
@@ -182,6 +193,7 @@ public sealed class DebugSessionManager : IAsyncDisposable
             ? new BreakpointsSnapshot(
                 Array.Empty<LineBreakpoint>(),
                 Array.Empty<FunctionBreakpoint>(),
+                Array.Empty<DataBreakpoint>(),
                 Array.Empty<string>())
             : _session.BreakpointsSnapshot();
 

--- a/src/AspNetCoreDebuggerMcp/Debugging/DebugSessionManager.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/DebugSessionManager.cs
@@ -118,10 +118,10 @@ public sealed class DebugSessionManager : IAsyncDisposable
         => RequireActiveSession().ListThreadsAsync(ct);
 
     public Task<IReadOnlyList<StackFrame>> GetStackTraceAsync(
-        int? threadId, int? startFrame, int? levels, CancellationToken ct)
+        int? threadId, int? startFrame, int? levels, bool raw, CancellationToken ct)
     {
         var s = RequireActiveSession();
-        return s.GetStackTraceAsync(ResolveThreadIdOrThrow(threadId), startFrame, levels, ct);
+        return s.GetStackTraceAsync(ResolveThreadIdOrThrow(threadId), startFrame, levels, raw, ct);
     }
 
     public async Task<IReadOnlyList<ScopeWithVariables>> GetScopesAsync(

--- a/src/AspNetCoreDebuggerMcp/Debugging/DebugSessionManager.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/DebugSessionManager.cs
@@ -1,9 +1,15 @@
 using AspNetCoreDebuggerMcp.Breakpoints;
+using AspNetCoreDebuggerMcp.Inspection;
 
 namespace AspNetCoreDebuggerMcp.Debugging;
 
-/// Combined result of a wait-for-stop call: the stop event and the current session snapshot.
-public sealed record WaitResult(StopInfo Stop, SessionSnapshot Session);
+/// Combined result of a wait-for-stop call: the stop event, the current session snapshot,
+/// and auto-context (top frame + source snippet) when the stopped thread is known.
+public sealed record WaitResult(
+    StopInfo Stop,
+    SessionSnapshot Session,
+    StackFrame? TopFrame,
+    SourceSnippet? Snippet);
 
 /// Holds the single active debug session. Session-lifecycle calls (launch/attach/disconnect)
 /// are serialised under a semaphore so concurrent tool invocations cannot race. Within a session,
@@ -89,7 +95,69 @@ public sealed class DebugSessionManager : IAsyncDisposable
     {
         var s = RequireActiveSession();
         var stop = await s.WaitForStopAsync(timeout, ct).ConfigureAwait(false);
-        return new WaitResult(stop, s.Snapshot());
+
+        // Auto-context-on-stop: best-effort top frame + source snippet for the stopped thread.
+        StackFrame? topFrame = null;
+        SourceSnippet? snippet = null;
+        if (stop.ThreadId is int tid)
+        {
+            try { topFrame = await s.GetTopFrameAsync(tid, ct).ConfigureAwait(false); }
+            catch { /* best-effort; auto-context is opportunistic */ }
+
+            if (topFrame is { SourcePath: { } path, Line: int line })
+                snippet = InspectionService.TryReadSnippet(path, line);
+        }
+
+        return new WaitResult(stop, s.Snapshot(), topFrame, snippet);
+    }
+
+    // ---- inspection passthroughs ---------------------------------------------------
+
+    public Task<IReadOnlyList<ThreadInfo>> ListThreadsAsync(CancellationToken ct)
+        => RequireActiveSession().ListThreadsAsync(ct);
+
+    public Task<IReadOnlyList<StackFrame>> GetStackTraceAsync(
+        int? threadId, int? startFrame, int? levels, CancellationToken ct)
+    {
+        var s = RequireActiveSession();
+        return s.GetStackTraceAsync(ResolveThreadIdOrThrow(threadId), startFrame, levels, ct);
+    }
+
+    public async Task<IReadOnlyList<ScopeWithVariables>> GetScopesAsync(
+        int? frameId, int depth, int maxChildren, CancellationToken ct)
+    {
+        var s = RequireActiveSession();
+        int fid = frameId ?? await ResolveTopFrameIdAsync(s, ct).ConfigureAwait(false);
+        return await s.GetScopesAsync(fid, depth, maxChildren, ct).ConfigureAwait(false);
+    }
+
+    public Task<EvaluateResult> EvaluateAsync(string expression, int? frameId, CancellationToken ct)
+        => RequireActiveSession().EvaluateAsync(expression, frameId, ct);
+
+    public Task<EvaluateResult> SetExpressionAsync(
+        string expression, string value, int? frameId, CancellationToken ct)
+        => RequireActiveSession().SetExpressionAsync(expression, value, frameId, ct);
+
+    public Task<ExceptionAutopsy> AutopsyAsync(int? threadId, int topFrameCount, CancellationToken ct)
+    {
+        var s = RequireActiveSession();
+        return s.AutopsyAsync(ResolveThreadIdOrThrow(threadId), topFrameCount, ct);
+    }
+
+    private int ResolveThreadIdOrThrow(int? threadId)
+    {
+        if (threadId is int id) return id;
+        if (_session?.LastStop?.ThreadId is int t) return t;
+        throw new DebugException("No current thread known. Pass threadId explicitly, or wait for a stop first.");
+    }
+
+    private static async Task<int> ResolveTopFrameIdAsync(DebugSession s, CancellationToken ct)
+    {
+        if (s.LastStop?.ThreadId is not int tid)
+            throw new DebugException("No current thread known. Pass frameId explicitly, or wait for a stop first.");
+        var top = await s.GetTopFrameAsync(tid, ct).ConfigureAwait(false)
+            ?? throw new DebugException("Could not determine the top frame.");
+        return top.Id;
     }
 
     // ---- breakpoints ----------------------------------------------------------------

--- a/src/AspNetCoreDebuggerMcp/Debugging/DebugSessionManager.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/DebugSessionManager.cs
@@ -1,0 +1,80 @@
+namespace AspNetCoreDebuggerMcp.Debugging;
+
+/// Holds the single active debug session. Serializes all session-lifecycle calls
+/// (launch/attach/disconnect) so concurrent tool invocations cannot race.
+public sealed class DebugSessionManager : IAsyncDisposable
+{
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private DebugSession? _session;
+
+    public async Task<SessionSnapshot> LaunchAsync(
+        string program, string[]? args, string? cwd, bool stopAtEntry, CancellationToken ct)
+    {
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            EnsureNoActiveSession();
+            await DisposeTerminatedAsync().ConfigureAwait(false);
+            var path = NetcoredbgLocator.Locate();
+            _session = await DebugSession.LaunchAsync(path, program, args, cwd, stopAtEntry, ct)
+                .ConfigureAwait(false);
+            return _session.Snapshot();
+        }
+        finally { _gate.Release(); }
+    }
+
+    public async Task<SessionSnapshot> AttachAsync(int processId, CancellationToken ct)
+    {
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            EnsureNoActiveSession();
+            await DisposeTerminatedAsync().ConfigureAwait(false);
+            var path = NetcoredbgLocator.Locate();
+            _session = await DebugSession.AttachAsync(path, processId, ct).ConfigureAwait(false);
+            return _session.Snapshot();
+        }
+        finally { _gate.Release(); }
+    }
+
+    public async Task<SessionSnapshot> DisconnectAsync(CancellationToken ct)
+    {
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (_session is null) return SessionSnapshot.None;
+            try { await _session.DisconnectAsync(ct).ConfigureAwait(false); } catch { }
+            await _session.DisposeAsync().ConfigureAwait(false);
+            _session = null;
+            return SessionSnapshot.None;
+        }
+        finally { _gate.Release(); }
+    }
+
+    public SessionSnapshot GetState()
+        => _session is null ? SessionSnapshot.None : _session.Snapshot();
+
+    private void EnsureNoActiveSession()
+    {
+        if (_session is not null && _session.State != SessionState.Terminated)
+            throw new DebugException(
+                "A debug session is already active. Call debug_disconnect before starting a new one.");
+    }
+
+    private async Task DisposeTerminatedAsync()
+    {
+        if (_session is null) return;
+        try { await _session.DisposeAsync().ConfigureAwait(false); } catch { }
+        _session = null;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_session is not null)
+        {
+            try { await _session.DisposeAsync().ConfigureAwait(false); } catch { }
+            _session = null;
+        }
+        _gate.Dispose();
+    }
+}

--- a/src/AspNetCoreDebuggerMcp/Debugging/DebugSessionManager.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/DebugSessionManager.cs
@@ -1,45 +1,53 @@
+using AspNetCoreDebuggerMcp.Breakpoints;
+
 namespace AspNetCoreDebuggerMcp.Debugging;
 
-/// Holds the single active debug session. Serializes all session-lifecycle calls
-/// (launch/attach/disconnect) so concurrent tool invocations cannot race.
+/// Combined result of a wait-for-stop call: the stop event and the current session snapshot.
+public sealed record WaitResult(StopInfo Stop, SessionSnapshot Session);
+
+/// Holds the single active debug session. Session-lifecycle calls (launch/attach/disconnect)
+/// are serialised under a semaphore so concurrent tool invocations cannot race. Within a session,
+/// execution and breakpoint calls pass through directly — the session's own state is thread-safe.
 public sealed class DebugSessionManager : IAsyncDisposable
 {
-    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly SemaphoreSlim _lifecycleGate = new(1, 1);
     private DebugSession? _session;
+
+    // ---- session lifecycle ----------------------------------------------------------
 
     public async Task<SessionSnapshot> LaunchAsync(
         string program, string[]? args, string? cwd, bool stopAtEntry, CancellationToken ct)
     {
-        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        await _lifecycleGate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
             EnsureNoActiveSession();
-            await DisposeTerminatedAsync().ConfigureAwait(false);
+            await DisposeExistingAsync().ConfigureAwait(false);
             var path = NetcoredbgLocator.Locate();
             _session = await DebugSession.LaunchAsync(path, program, args, cwd, stopAtEntry, ct)
                 .ConfigureAwait(false);
             return _session.Snapshot();
         }
-        finally { _gate.Release(); }
+        finally { _lifecycleGate.Release(); }
     }
 
     public async Task<SessionSnapshot> AttachAsync(int processId, CancellationToken ct)
     {
-        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        await _lifecycleGate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
             EnsureNoActiveSession();
-            await DisposeTerminatedAsync().ConfigureAwait(false);
+            await DisposeExistingAsync().ConfigureAwait(false);
             var path = NetcoredbgLocator.Locate();
             _session = await DebugSession.AttachAsync(path, processId, ct).ConfigureAwait(false);
             return _session.Snapshot();
         }
-        finally { _gate.Release(); }
+        finally { _lifecycleGate.Release(); }
     }
 
     public async Task<SessionSnapshot> DisconnectAsync(CancellationToken ct)
     {
-        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        await _lifecycleGate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
             if (_session is null) return SessionSnapshot.None;
@@ -48,11 +56,76 @@ public sealed class DebugSessionManager : IAsyncDisposable
             _session = null;
             return SessionSnapshot.None;
         }
-        finally { _gate.Release(); }
+        finally { _lifecycleGate.Release(); }
     }
 
     public SessionSnapshot GetState()
         => _session is null ? SessionSnapshot.None : _session.Snapshot();
+
+    // ---- execution control ----------------------------------------------------------
+
+    public async Task<SessionSnapshot> ContinueAsync(int? threadId, CancellationToken ct)
+    {
+        var s = RequireActiveSession();
+        await s.ContinueAsync(threadId, ct).ConfigureAwait(false);
+        return s.Snapshot();
+    }
+
+    public async Task<SessionSnapshot> PauseAsync(int? threadId, CancellationToken ct)
+    {
+        var s = RequireActiveSession();
+        await s.PauseAsync(threadId, ct).ConfigureAwait(false);
+        return s.Snapshot();
+    }
+
+    public async Task<SessionSnapshot> StepAsync(string kind, int? threadId, CancellationToken ct)
+    {
+        var s = RequireActiveSession();
+        await s.StepAsync(kind, threadId, ct).ConfigureAwait(false);
+        return s.Snapshot();
+    }
+
+    public async Task<WaitResult> WaitForStopAsync(TimeSpan timeout, CancellationToken ct)
+    {
+        var s = RequireActiveSession();
+        var stop = await s.WaitForStopAsync(timeout, ct).ConfigureAwait(false);
+        return new WaitResult(stop, s.Snapshot());
+    }
+
+    // ---- breakpoints ----------------------------------------------------------------
+
+    public Task<LineBreakpoint> AddLineBreakpointAsync(
+        string sourcePath, int line, string? condition, string? hitCondition, string? logMessage,
+        CancellationToken ct)
+        => RequireActiveSession().AddLineBreakpointAsync(sourcePath, line, condition, hitCondition, logMessage, ct);
+
+    public Task<FunctionBreakpoint> AddFunctionBreakpointAsync(
+        string functionName, string? condition, string? hitCondition, CancellationToken ct)
+        => RequireActiveSession().AddFunctionBreakpointAsync(functionName, condition, hitCondition, ct);
+
+    public Task<bool> RemoveBreakpointAsync(string id, CancellationToken ct)
+        => RequireActiveSession().RemoveBreakpointAsync(id, ct);
+
+    public Task SetExceptionFiltersAsync(IEnumerable<string> filters, CancellationToken ct)
+        => RequireActiveSession().SetExceptionFiltersAsync(filters, ct);
+
+    public BreakpointsSnapshot ListBreakpoints()
+        => _session is null
+            ? new BreakpointsSnapshot(
+                Array.Empty<LineBreakpoint>(),
+                Array.Empty<FunctionBreakpoint>(),
+                Array.Empty<string>())
+            : _session.BreakpointsSnapshot();
+
+    // ---- helpers --------------------------------------------------------------------
+
+    private DebugSession RequireActiveSession()
+    {
+        if (_session is null || _session.State == SessionState.Terminated)
+            throw new DebugException(
+                "No active debug session. Call debug_launch or debug_attach first.");
+        return _session;
+    }
 
     private void EnsureNoActiveSession()
     {
@@ -61,7 +134,7 @@ public sealed class DebugSessionManager : IAsyncDisposable
                 "A debug session is already active. Call debug_disconnect before starting a new one.");
     }
 
-    private async Task DisposeTerminatedAsync()
+    private async Task DisposeExistingAsync()
     {
         if (_session is null) return;
         try { await _session.DisposeAsync().ConfigureAwait(false); } catch { }
@@ -75,6 +148,6 @@ public sealed class DebugSessionManager : IAsyncDisposable
             try { await _session.DisposeAsync().ConfigureAwait(false); } catch { }
             _session = null;
         }
-        _gate.Dispose();
+        _lifecycleGate.Dispose();
     }
 }

--- a/src/AspNetCoreDebuggerMcp/Debugging/NetcoredbgLocator.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/NetcoredbgLocator.cs
@@ -1,0 +1,44 @@
+namespace AspNetCoreDebuggerMcp.Debugging;
+
+/// Finds the netcoredbg executable on disk.
+/// Resolution order: NETCOREDBG_PATH env var → bundled-next-to-assembly → on PATH.
+internal static class NetcoredbgLocator
+{
+    public const string EnvironmentVariable = "NETCOREDBG_PATH";
+
+    public static string Locate()
+    {
+        var envPath = Environment.GetEnvironmentVariable(EnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(envPath) && File.Exists(envPath))
+            return envPath;
+
+        var baseDir = AppContext.BaseDirectory;
+        foreach (var candidate in new[]
+        {
+            Path.Combine(baseDir, "netcoredbg", "netcoredbg"),
+            Path.Combine(baseDir, "netcoredbg"),
+        })
+        {
+            if (File.Exists(candidate)) return candidate;
+        }
+
+        var onPath = FindOnPath("netcoredbg");
+        if (onPath is not null) return onPath;
+
+        throw new FileNotFoundException(
+            $"netcoredbg executable not found. Set the {EnvironmentVariable} environment variable " +
+            "to the netcoredbg binary, or place it on PATH.");
+    }
+
+    private static string? FindOnPath(string name)
+    {
+        var path = Environment.GetEnvironmentVariable("PATH") ?? "";
+        foreach (var dir in path.Split(Path.PathSeparator))
+        {
+            if (string.IsNullOrWhiteSpace(dir)) continue;
+            var full = Path.Combine(dir, name);
+            if (File.Exists(full)) return full;
+        }
+        return null;
+    }
+}

--- a/src/AspNetCoreDebuggerMcp/Debugging/NetcoredbgProcess.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/NetcoredbgProcess.cs
@@ -1,0 +1,55 @@
+using System.Diagnostics;
+
+namespace AspNetCoreDebuggerMcp.Debugging;
+
+/// Owns a child netcoredbg process running in DAP (vscode) interpreter mode.
+/// Exposes the input/output streams that a DAP client reads from / writes to.
+internal sealed class NetcoredbgProcess : IAsyncDisposable
+{
+    private readonly Process _process;
+
+    public Stream Input => _process.StandardOutput.BaseStream;   // we READ netcoredbg's stdout
+    public Stream Output => _process.StandardInput.BaseStream;   // we WRITE to netcoredbg's stdin
+
+    private NetcoredbgProcess(Process process) => _process = process;
+
+    public static NetcoredbgProcess Start(string netcoredbgPath)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = netcoredbgPath,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        psi.ArgumentList.Add("--interpreter=vscode");
+
+        var process = Process.Start(psi)
+            ?? throw new InvalidOperationException($"Failed to start netcoredbg at {netcoredbgPath}");
+        return new NetcoredbgProcess(process);
+    }
+
+    public bool HasExited => _process.HasExited;
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            if (!_process.HasExited)
+            {
+                _process.Kill(entireProcessTree: true);
+                await _process.WaitForExitAsync().ConfigureAwait(false);
+            }
+        }
+        catch
+        {
+            // dispose is best-effort
+        }
+        finally
+        {
+            _process.Dispose();
+        }
+    }
+}

--- a/src/AspNetCoreDebuggerMcp/Debugging/SessionSnapshot.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/SessionSnapshot.cs
@@ -1,0 +1,11 @@
+namespace AspNetCoreDebuggerMcp.Debugging;
+
+public sealed record StopInfo(string Reason, int? ThreadId, string? Description);
+
+public sealed record SessionSnapshot(
+    string State,
+    int? ProcessId,
+    StopInfo? LastStop)
+{
+    public static SessionSnapshot None { get; } = new("None", null, null);
+}

--- a/src/AspNetCoreDebuggerMcp/Debugging/SessionState.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/SessionState.cs
@@ -1,0 +1,10 @@
+namespace AspNetCoreDebuggerMcp.Debugging;
+
+public enum SessionState
+{
+    Initializing,
+    Configuring,
+    Running,
+    Paused,
+    Terminated,
+}

--- a/src/AspNetCoreDebuggerMcp/Debugging/SessionStateMachine.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/SessionStateMachine.cs
@@ -1,0 +1,33 @@
+namespace AspNetCoreDebuggerMcp.Debugging;
+
+/// Pure state machine for a debug session. Extracted from DebugSession so transitions
+/// can be unit-tested without spinning up a real debugger.
+///
+/// Invariant: once Terminated, the session stays Terminated — late stopped/continued
+/// events from a dying adapter must not resurrect it.
+internal sealed class SessionStateMachine
+{
+    private readonly object _gate = new();
+    private SessionState _state;
+
+    public SessionStateMachine(SessionState initial = SessionState.Initializing)
+        => _state = initial;
+
+    public SessionState State { get { lock (_gate) return _state; } }
+
+    public void Transition(SessionState target)
+    {
+        lock (_gate)
+        {
+            if (_state == SessionState.Terminated) return;
+            _state = target;
+        }
+    }
+
+    public void OnStopped()      => Transition(SessionState.Paused);
+    public void OnContinued()    => Transition(SessionState.Running);
+    public void OnTerminated()
+    {
+        lock (_gate) _state = SessionState.Terminated;
+    }
+}

--- a/src/AspNetCoreDebuggerMcp/Debugging/StopWaiter.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/StopWaiter.cs
@@ -1,0 +1,52 @@
+namespace AspNetCoreDebuggerMcp.Debugging;
+
+/// One-shot waiter for the *next* stop event after a continue/step.
+///
+/// Reset() must be called synchronously inside Continue/Step (before the DAP request is sent)
+/// so that a wait registered immediately afterward sees a fresh, uncompleted TCS. If we instead
+/// reset on the `continued` event we'd race the agent's wait: it could observe the previous
+/// (completed) stop's TCS and return immediately with stale info.
+internal sealed class StopWaiter
+{
+    private readonly object _gate = new();
+    private TaskCompletionSource<StopInfo> _tcs =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private bool _terminated;
+
+    /// Replace the TCS with a fresh uncompleted one. No-op once terminated.
+    public void Reset()
+    {
+        lock (_gate)
+        {
+            if (_terminated) return;
+            _tcs = new TaskCompletionSource<StopInfo>(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+    }
+
+    /// Complete the current TCS with the stop information. Subsequent SetStop calls (until Reset)
+    /// are no-ops; the first stop wins.
+    public void SetStop(StopInfo info)
+    {
+        TaskCompletionSource<StopInfo> tcs;
+        lock (_gate) tcs = _tcs;
+        tcs.TrySetResult(info);
+    }
+
+    /// Mark as terminated; the current pending TCS is faulted and any further Reset is suppressed.
+    public void Terminate()
+    {
+        lock (_gate)
+        {
+            _terminated = true;
+            _tcs.TrySetException(new DebugException("Debug session terminated."));
+        }
+    }
+
+    /// Wait for the current TCS to complete, honouring the cancellation token.
+    public Task<StopInfo> WaitAsync(CancellationToken ct)
+    {
+        TaskCompletionSource<StopInfo> tcs;
+        lock (_gate) tcs = _tcs;
+        return tcs.Task.WaitAsync(ct);
+    }
+}

--- a/src/AspNetCoreDebuggerMcp/Diagnostics/OutputLine.cs
+++ b/src/AspNetCoreDebuggerMcp/Diagnostics/OutputLine.cs
@@ -1,0 +1,3 @@
+namespace AspNetCoreDebuggerMcp.Diagnostics;
+
+public sealed record OutputLine(string Category, string Output, DateTimeOffset Timestamp);

--- a/src/AspNetCoreDebuggerMcp/Diagnostics/ThreadAnalyzer.cs
+++ b/src/AspNetCoreDebuggerMcp/Diagnostics/ThreadAnalyzer.cs
@@ -1,0 +1,67 @@
+namespace AspNetCoreDebuggerMcp.Diagnostics;
+
+public enum BlockingKind
+{
+    Running,
+    BlockedOnMonitor,        // Monitor.Wait / Monitor.Enter
+    BlockedOnWaitHandle,     // WaitHandle.WaitOne / WaitAll / WaitAny / ManualResetEvent / AutoResetEvent
+    BlockedOnSemaphore,      // SemaphoreSlim.Wait / Semaphore.WaitOne
+    BlockedOnTask,           // Task.Wait / Task.Result / GetAwaiter().GetResult
+    BlockedOnThreadJoin,     // Thread.Join
+    Sleeping,                // Thread.Sleep / Task.Delay (sync wait)
+    AwaitingAsync,           // AsyncTaskMethodBuilder / state machine MoveNext awaiting
+}
+
+public sealed record ThreadHangInfo(int ThreadId, string Name, BlockingKind BlockingKind, IReadOnlyList<string> TopFrameNames);
+
+public sealed record HangAnalysis(
+    IReadOnlyList<ThreadHangInfo> Threads,
+    int BlockedCount,
+    bool CycleDetectionAvailable,
+    string Notes);
+
+/// Pure stack-frame classifier. Looks at the top N frame names of a thread and
+/// returns the most-likely blocking pattern. The first frame is treated as the
+/// most recent (topmost) call.
+public static class ThreadAnalyzer
+{
+    public static BlockingKind Classify(IReadOnlyList<string> topFrameNames)
+    {
+        foreach (var raw in topFrameNames)
+        {
+            var name = raw ?? "";
+            if (Contains(name, "Monitor.Wait") || Contains(name, "Monitor.Enter") ||
+                Contains(name, "Monitor.TryEnter") || Contains(name, "lock(")) return BlockingKind.BlockedOnMonitor;
+
+            if (Contains(name, "SemaphoreSlim.Wait") || Contains(name, "Semaphore.WaitOne")) return BlockingKind.BlockedOnSemaphore;
+
+            if (Contains(name, "WaitHandle.Wait") || Contains(name, "ManualResetEvent.WaitOne") ||
+                Contains(name, "AutoResetEvent.WaitOne") || Contains(name, "ManualResetEventSlim.Wait")) return BlockingKind.BlockedOnWaitHandle;
+
+            if (Contains(name, "Task.Wait") || Contains(name, "Task`1.get_Result") ||
+                Contains(name, "TaskAwaiter.GetResult") || Contains(name, "GetAwaiter().GetResult")) return BlockingKind.BlockedOnTask;
+
+            if (Contains(name, "Thread.Join")) return BlockingKind.BlockedOnThreadJoin;
+            if (Contains(name, "Thread.Sleep") || Contains(name, "Task.Delay")) return BlockingKind.Sleeping;
+
+            if (Contains(name, "AwaitUnsafeOnCompleted") || Contains(name, "AsyncTaskMethodBuilder")) return BlockingKind.AwaitingAsync;
+        }
+        return BlockingKind.Running;
+    }
+
+    public static HangAnalysis Analyze(IEnumerable<ThreadHangInfo> threads)
+    {
+        var list = threads.ToList();
+        var blocked = list.Count(t => t.BlockingKind != BlockingKind.Running);
+        return new HangAnalysis(
+            Threads: list,
+            BlockedCount: blocked,
+            CycleDetectionAvailable: false,
+            Notes: blocked == 0
+                ? "No threads appear blocked on a known synchronization primitive."
+                : "Cycle detection requires lock-ownership data which DAP does not expose. Inspect the stacks to determine causality.");
+    }
+
+    private static bool Contains(string haystack, string needle)
+        => haystack.IndexOf(needle, StringComparison.Ordinal) >= 0;
+}

--- a/src/AspNetCoreDebuggerMcp/Inspection/AsyncStackFlattener.cs
+++ b/src/AspNetCoreDebuggerMcp/Inspection/AsyncStackFlattener.cs
@@ -1,0 +1,59 @@
+using System.Text.RegularExpressions;
+
+namespace AspNetCoreDebuggerMcp.Inspection;
+
+/// Pure post-processing for stack frames.
+///
+/// 1. Renames compiler-generated async state-machine frames back to the user's method name:
+///    `Ns.Foo.<MethodName>d__3.MoveNext()`  →  `Ns.Foo.MethodName()`
+/// 2. Optionally hides pure async/threading infrastructure frames (AsyncTaskMethodBuilder,
+///    ExecutionContext.Run, AwaitTaskContinuation, ThreadPool internals, …).
+///
+/// Line numbers are preserved as-is — we only touch the name string. Lambdas like
+/// `<>c.<<Main>$>b__0_0()` are intentionally left alone because they are not the outer method.
+public static class AsyncStackFlattener
+{
+    private static readonly Regex MoveNextRx = new(
+        @"\.<(?<m>[A-Za-z_][A-Za-z0-9_]*)>d__\d+\.MoveNext",
+        RegexOptions.Compiled);
+
+    private static readonly string[] InfrastructurePrefixes = new[]
+    {
+        "System.Runtime.CompilerServices.AsyncTaskMethodBuilder",
+        "System.Runtime.CompilerServices.AsyncMethodBuilderCore",
+        "System.Runtime.CompilerServices.AsyncStateMachineBox",
+        "System.Threading.ExecutionContext.Run",
+        "System.Threading.ExecutionContext.RunInternal",
+        "System.Threading.Tasks.AwaitTaskContinuation",
+        "System.Threading.Tasks.ContinuationTaskFromTask",
+        "System.Threading.Tasks.Task+",
+        "System.Threading.ThreadPoolWorkQueue",
+        "System.Threading.ThreadPool.",
+        "System.Threading.PortableThreadPool",
+        "System.Threading.Thread.StartHelper",
+    };
+
+    public static IReadOnlyList<StackFrame> Flatten(
+        IReadOnlyList<StackFrame> frames, bool hideInfrastructure = true)
+    {
+        var result = new List<StackFrame>(frames.Count);
+        foreach (var f in frames)
+        {
+            if (hideInfrastructure && IsInfrastructure(f.Name)) continue;
+            result.Add(f with { Name = RewriteName(f.Name) });
+        }
+        return result;
+    }
+
+    public static string RewriteName(string name)
+        => MoveNextRx.IsMatch(name)
+            ? MoveNextRx.Replace(name, m => "." + m.Groups["m"].Value)
+            : name;
+
+    public static bool IsInfrastructure(string name)
+    {
+        foreach (var prefix in InfrastructurePrefixes)
+            if (name.StartsWith(prefix, StringComparison.Ordinal)) return true;
+        return false;
+    }
+}

--- a/src/AspNetCoreDebuggerMcp/Inspection/InspectionRecords.cs
+++ b/src/AspNetCoreDebuggerMcp/Inspection/InspectionRecords.cs
@@ -1,0 +1,52 @@
+namespace AspNetCoreDebuggerMcp.Inspection;
+
+public sealed record ThreadInfo(int Id, string Name);
+
+public sealed record StackFrame(
+    int Id,
+    string Name,
+    string? SourcePath,
+    int? Line,
+    int? Column);
+
+public sealed record VariableInfo(
+    string Name,
+    string Value,
+    string? Type,
+    int VariablesReference,
+    IReadOnlyList<VariableInfo>? Children,
+    int? TotalChildren,
+    bool Truncated);
+
+public sealed record ScopeWithVariables(
+    string Name,
+    int VariablesReference,
+    bool Expensive,
+    IReadOnlyList<VariableInfo> Variables);
+
+public sealed record EvaluateResult(
+    string Result,
+    string? Type,
+    int VariablesReference);
+
+public sealed record SourceSnippet(
+    string Path,
+    int StartLine,
+    int EndLine,
+    int HighlightLine,
+    string Text);
+
+public sealed record ExceptionAutopsy(
+    string ThreadId,
+    string? ExceptionId,
+    string? Description,
+    string? BreakMode,
+    IReadOnlyList<ExceptionLayer> Layers,
+    IReadOnlyList<StackFrame> StackFrames,
+    IReadOnlyList<ScopeWithVariables>? TopFrameLocals,
+    SourceSnippet? TopFrameSnippet);
+
+public sealed record ExceptionLayer(
+    string? TypeName,
+    string? Message,
+    string? Source);

--- a/src/AspNetCoreDebuggerMcp/Inspection/InspectionService.cs
+++ b/src/AspNetCoreDebuggerMcp/Inspection/InspectionService.cs
@@ -1,0 +1,287 @@
+using System.Text;
+using System.Text.Json;
+using AspNetCoreDebuggerMcp.Dap;
+using AspNetCoreDebuggerMcp.Debugging;
+
+namespace AspNetCoreDebuggerMcp.Inspection;
+
+/// Per-session adapter that translates DAP threads / stackTrace / scopes / variables /
+/// evaluate / setExpression / exceptionInfo into our typed records, with smart variable
+/// expansion (depth + max-children truncation) and an exception_autopsy composite.
+internal sealed class InspectionService
+{
+    private readonly DapClient _client;
+
+    public InspectionService(DapClient client) => _client = client;
+
+    // ---- threads + stack -----------------------------------------------------------
+
+    public async Task<IReadOnlyList<ThreadInfo>> ListThreadsAsync(CancellationToken ct)
+    {
+        var resp = await _client.SendRequestAsync("threads", null, ct).ConfigureAwait(false);
+        if (!resp.Success) throw new DebugException($"threads failed: {resp.Message ?? "unknown"}");
+
+        var list = new List<ThreadInfo>();
+        if (resp.Body is { } body && body.TryGetProperty("threads", out var arr)
+            && arr.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var t in arr.EnumerateArray())
+            {
+                var id = ReadInt(t, "id") ?? 0;
+                var name = ReadString(t, "name") ?? "";
+                list.Add(new ThreadInfo(id, name));
+            }
+        }
+        return list;
+    }
+
+    public async Task<IReadOnlyList<StackFrame>> GetStackTraceAsync(
+        int threadId, int? startFrame, int? levels, CancellationToken ct)
+    {
+        var args = new Dictionary<string, object?> { ["threadId"] = threadId };
+        if (startFrame is int s) args["startFrame"] = s;
+        if (levels is int l) args["levels"] = l;
+        var resp = await _client.SendRequestAsync("stackTrace", args, ct).ConfigureAwait(false);
+        if (!resp.Success) throw new DebugException($"stackTrace failed: {resp.Message ?? "unknown"}");
+
+        var list = new List<StackFrame>();
+        if (resp.Body is { } body && body.TryGetProperty("stackFrames", out var arr)
+            && arr.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var f in arr.EnumerateArray()) list.Add(ParseFrame(f));
+        }
+        return list;
+    }
+
+    public async Task<StackFrame?> GetTopFrameAsync(int threadId, CancellationToken ct)
+    {
+        var frames = await GetStackTraceAsync(threadId, 0, 1, ct).ConfigureAwait(false);
+        return frames.Count > 0 ? frames[0] : null;
+    }
+
+    private static StackFrame ParseFrame(JsonElement f)
+    {
+        var id = ReadInt(f, "id") ?? 0;
+        var name = ReadString(f, "name") ?? "";
+        string? path = null;
+        if (f.TryGetProperty("source", out var src) && src.ValueKind == JsonValueKind.Object)
+            path = ReadString(src, "path");
+        var line = ReadInt(f, "line");
+        var col = ReadInt(f, "column");
+        return new StackFrame(id, name, path, line, col);
+    }
+
+    // ---- scopes + variables --------------------------------------------------------
+
+    public async Task<IReadOnlyList<ScopeWithVariables>> GetScopesAsync(
+        int frameId, int depth, int maxChildren, CancellationToken ct)
+    {
+        var resp = await _client.SendRequestAsync("scopes", new { frameId }, ct).ConfigureAwait(false);
+        if (!resp.Success) throw new DebugException($"scopes failed: {resp.Message ?? "unknown"}");
+
+        var scopes = new List<ScopeWithVariables>();
+        if (resp.Body is { } body && body.TryGetProperty("scopes", out var arr)
+            && arr.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var s in arr.EnumerateArray())
+            {
+                var name = ReadString(s, "name") ?? "";
+                var varRef = ReadInt(s, "variablesReference") ?? 0;
+                var expensive = s.TryGetProperty("expensive", out var ex) && ex.ValueKind == JsonValueKind.True;
+                var vars = varRef > 0
+                    ? await FetchVariablesAsync(varRef, depth, maxChildren, ct).ConfigureAwait(false)
+                    : Array.Empty<VariableInfo>();
+                scopes.Add(new ScopeWithVariables(name, varRef, expensive, vars));
+            }
+        }
+        return scopes;
+    }
+
+    /// Fetch the variables for a container reference, recursively up to `remainingDepth` levels.
+    /// At depth 1 we fetch this container's immediate children but no further; at depth 2 we
+    /// also fetch grandchildren; etc.
+    private async Task<IReadOnlyList<VariableInfo>> FetchVariablesAsync(
+        int variablesReference, int remainingDepth, int maxChildren, CancellationToken ct)
+    {
+        var resp = await _client.SendRequestAsync("variables",
+            new { variablesReference }, ct).ConfigureAwait(false);
+        if (!resp.Success) return Array.Empty<VariableInfo>();
+
+        var all = new List<JsonElement>();
+        if (resp.Body is { } body && body.TryGetProperty("variables", out var arr)
+            && arr.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var v in arr.EnumerateArray()) all.Add(v);
+        }
+
+        var taken = all.Count > maxChildren ? all.Take(maxChildren).ToList() : all;
+        var truncated = all.Count > maxChildren;
+        var totalIfTruncated = truncated ? (int?)all.Count : null;
+
+        var results = new List<VariableInfo>(taken.Count);
+        foreach (var v in taken)
+        {
+            var name = ReadString(v, "name") ?? "";
+            var value = ReadString(v, "value") ?? "";
+            var type = ReadString(v, "type");
+            var childRef = ReadInt(v, "variablesReference") ?? 0;
+            IReadOnlyList<VariableInfo>? children = null;
+            int? childTotal = null;
+            bool childTrunc = false;
+            if (childRef > 0 && remainingDepth > 1)
+            {
+                children = await FetchVariablesAsync(childRef, remainingDepth - 1, maxChildren, ct)
+                    .ConfigureAwait(false);
+            }
+            results.Add(new VariableInfo(name, value, type, childRef, children, childTotal, childTrunc));
+        }
+
+        // Truncation info for THIS level is recorded on the parent (the caller's scope/var).
+        // For the scope itself, GetScopesAsync attaches the list as-is — callers can detect
+        // truncation by comparing the returned count to maxChildren and/or by the per-VariableInfo
+        // TotalChildren on parents.
+        return results;
+    }
+
+    // ---- evaluate + set ------------------------------------------------------------
+
+    public async Task<EvaluateResult> EvaluateAsync(string expression, int? frameId, CancellationToken ct)
+    {
+        var args = new Dictionary<string, object?>
+        {
+            ["expression"] = expression,
+            ["context"] = "repl",
+        };
+        if (frameId is int fid) args["frameId"] = fid;
+
+        var resp = await _client.SendRequestAsync("evaluate", args, ct).ConfigureAwait(false);
+        if (!resp.Success) throw new DebugException($"evaluate failed: {resp.Message ?? "unknown"}");
+
+        var body = resp.Body!.Value;
+        return new EvaluateResult(
+            ReadString(body, "result") ?? "",
+            ReadString(body, "type"),
+            ReadInt(body, "variablesReference") ?? 0);
+    }
+
+    public async Task<EvaluateResult> SetExpressionAsync(
+        string expression, string value, int? frameId, CancellationToken ct)
+    {
+        var args = new Dictionary<string, object?>
+        {
+            ["expression"] = expression,
+            ["value"] = value,
+        };
+        if (frameId is int fid) args["frameId"] = fid;
+
+        var resp = await _client.SendRequestAsync("setExpression", args, ct).ConfigureAwait(false);
+        if (!resp.Success) throw new DebugException($"setExpression failed: {resp.Message ?? "unknown"}");
+
+        var body = resp.Body!.Value;
+        return new EvaluateResult(
+            ReadString(body, "value") ?? "",
+            ReadString(body, "type"),
+            ReadInt(body, "variablesReference") ?? 0);
+    }
+
+    // ---- exception autopsy ---------------------------------------------------------
+
+    public async Task<ExceptionAutopsy> AutopsyAsync(int threadId, int topFrameCount, CancellationToken ct)
+    {
+        string? exceptionId = null, description = null, breakMode = null;
+        var layers = new List<ExceptionLayer>();
+
+        try
+        {
+            var resp = await _client.SendRequestAsync("exceptionInfo",
+                new { threadId }, ct).ConfigureAwait(false);
+            if (resp.Success && resp.Body is { } body)
+            {
+                exceptionId = ReadString(body, "exceptionId");
+                description = ReadString(body, "description");
+                breakMode = ReadString(body, "breakMode");
+                if (body.TryGetProperty("details", out var details)
+                    && details.ValueKind == JsonValueKind.Object)
+                {
+                    CollectLayers(details, layers);
+                }
+            }
+        }
+        catch { /* exceptionInfo may not be available; continue with what we have */ }
+
+        var frames = await GetStackTraceAsync(threadId, 0, topFrameCount, ct).ConfigureAwait(false);
+
+        IReadOnlyList<ScopeWithVariables>? topLocals = null;
+        SourceSnippet? snippet = null;
+        if (frames.Count > 0)
+        {
+            try
+            {
+                topLocals = await GetScopesAsync(frames[0].Id, depth: 1, maxChildren: 50, ct)
+                    .ConfigureAwait(false);
+            }
+            catch { /* best-effort */ }
+
+            if (frames[0].SourcePath is { } path && frames[0].Line is int line)
+                snippet = TryReadSnippet(path, line);
+        }
+
+        return new ExceptionAutopsy(
+            threadId.ToString(), exceptionId, description, breakMode, layers, frames, topLocals, snippet);
+    }
+
+    private static void CollectLayers(JsonElement details, List<ExceptionLayer> layers)
+    {
+        var typeName = ReadString(details, "fullTypeName") ?? ReadString(details, "typeName");
+        var message = ReadString(details, "message");
+        var source = ReadString(details, "source");
+        layers.Add(new ExceptionLayer(typeName, message, source));
+
+        if (details.TryGetProperty("innerException", out var inner)
+            && inner.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var i in inner.EnumerateArray())
+                if (i.ValueKind == JsonValueKind.Object) CollectLayers(i, layers);
+        }
+    }
+
+    // ---- source snippet ------------------------------------------------------------
+
+    /// Best-effort: read a few lines around the highlighted line and return them
+    /// in a printable form. Returns null if the file cannot be read.
+    public static SourceSnippet? TryReadSnippet(string path, int highlightLine, int radius = 3)
+    {
+        try
+        {
+            if (!File.Exists(path)) return null;
+            var lines = File.ReadAllLines(path);
+            int start = Math.Max(1, highlightLine - radius);
+            int end = Math.Min(lines.Length, highlightLine + radius);
+            var sb = new StringBuilder();
+            for (int i = start; i <= end; i++)
+            {
+                var marker = i == highlightLine ? "→ " : "  ";
+                sb.Append(marker).Append(i.ToString().PadLeft(4)).Append(": ").AppendLine(lines[i - 1]);
+            }
+            return new SourceSnippet(path, start, end, highlightLine, sb.ToString());
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    // ---- helpers -------------------------------------------------------------------
+
+    private static string? ReadString(JsonElement e, string name)
+    {
+        if (!e.TryGetProperty(name, out var v)) return null;
+        return v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+    }
+
+    private static int? ReadInt(JsonElement e, string name)
+    {
+        if (!e.TryGetProperty(name, out var v)) return null;
+        return v.ValueKind == JsonValueKind.Number ? v.GetInt32() : null;
+    }
+}

--- a/src/AspNetCoreDebuggerMcp/Inspection/InspectionService.cs
+++ b/src/AspNetCoreDebuggerMcp/Inspection/InspectionService.cs
@@ -36,7 +36,7 @@ internal sealed class InspectionService
     }
 
     public async Task<IReadOnlyList<StackFrame>> GetStackTraceAsync(
-        int threadId, int? startFrame, int? levels, CancellationToken ct)
+        int threadId, int? startFrame, int? levels, bool raw, CancellationToken ct)
     {
         var args = new Dictionary<string, object?> { ["threadId"] = threadId };
         if (startFrame is int s) args["startFrame"] = s;
@@ -50,12 +50,15 @@ internal sealed class InspectionService
         {
             foreach (var f in arr.EnumerateArray()) list.Add(ParseFrame(f));
         }
-        return list;
+
+        return raw ? list : AsyncStackFlattener.Flatten(list, hideInfrastructure: true);
     }
 
     public async Task<StackFrame?> GetTopFrameAsync(int threadId, CancellationToken ct)
     {
-        var frames = await GetStackTraceAsync(threadId, 0, 1, ct).ConfigureAwait(false);
+        // Always flatten the top frame name so auto-context shows "Foo.BarAsync" instead of
+        // "Foo.<BarAsync>d__3.MoveNext". Single frame, so no infrastructure to skip.
+        var frames = await GetStackTraceAsync(threadId, 0, 1, raw: false, ct).ConfigureAwait(false);
         return frames.Count > 0 ? frames[0] : null;
     }
 
@@ -209,7 +212,7 @@ internal sealed class InspectionService
         }
         catch { /* exceptionInfo may not be available; continue with what we have */ }
 
-        var frames = await GetStackTraceAsync(threadId, 0, topFrameCount, ct).ConfigureAwait(false);
+        var frames = await GetStackTraceAsync(threadId, 0, topFrameCount, raw: false, ct).ConfigureAwait(false);
 
         IReadOnlyList<ScopeWithVariables>? topLocals = null;
         SourceSnippet? snippet = null;

--- a/src/AspNetCoreDebuggerMcp/Program.cs
+++ b/src/AspNetCoreDebuggerMcp/Program.cs
@@ -1,0 +1,20 @@
+using AspNetCoreDebuggerMcp.Debugging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+// MCP communicates over stdio: logs MUST go to stderr or they will corrupt the protocol stream.
+builder.Logging.ClearProviders();
+builder.Logging.AddConsole(o => o.LogToStandardErrorThreshold = LogLevel.Trace);
+
+builder.Services.AddSingleton<DebugSessionManager>();
+
+builder.Services
+    .AddMcpServer()
+    .WithStdioServerTransport()
+    .WithToolsFromAssembly();
+
+await builder.Build().RunAsync();

--- a/src/AspNetCoreDebuggerMcp/Tools/BreakpointTools.cs
+++ b/src/AspNetCoreDebuggerMcp/Tools/BreakpointTools.cs
@@ -73,6 +73,7 @@ public sealed class BreakpointTools
                 success = true,
                 line = snap.Line,
                 function = snap.Function,
+                data = snap.Data,
                 exceptionFilters = snap.ExceptionFilters,
             });
         }
@@ -89,6 +90,23 @@ public sealed class BreakpointTools
         {
             await _manager.SetExceptionFiltersAsync(filters ?? Array.Empty<string>(), ct).ConfigureAwait(false);
             return ToolResults.Serialize(new { success = true, exceptionFilters = filters });
+        }
+        catch (Exception ex) { return ToolResults.Err(ex); }
+    }
+
+    [McpServerTool(Name = "breakpoint_set_data")]
+    [Description("Set a data/watch breakpoint: break when a specific variable changes (or is read). Requires a variablesReference + name from variables_get. May not be supported by all adapters.")]
+    public async Task<string> SetDataAsync(
+        [Description("variablesReference of the container holding the variable (from variables_get).")] int variablesReference,
+        [Description("Name of the variable to watch.")] string name,
+        [Description("Access type: \"write\" (default), \"read\", or \"readWrite\".")] string accessType = "write",
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var bp = await _manager.AddDataBreakpointAsync(variablesReference, name, accessType, ct)
+                .ConfigureAwait(false);
+            return ToolResults.Serialize(new { success = true, breakpoint = bp });
         }
         catch (Exception ex) { return ToolResults.Err(ex); }
     }

--- a/src/AspNetCoreDebuggerMcp/Tools/BreakpointTools.cs
+++ b/src/AspNetCoreDebuggerMcp/Tools/BreakpointTools.cs
@@ -1,0 +1,95 @@
+using System.ComponentModel;
+using AspNetCoreDebuggerMcp.Debugging;
+using ModelContextProtocol.Server;
+
+namespace AspNetCoreDebuggerMcp.Tools;
+
+[McpServerToolType]
+public sealed class BreakpointTools
+{
+    private readonly DebugSessionManager _manager;
+
+    public BreakpointTools(DebugSessionManager manager) => _manager = manager;
+
+    [McpServerTool(Name = "breakpoint_set")]
+    [Description("Set a line breakpoint in a source file. Supports conditional, hit-count, and logpoint (logMessage) breakpoints.")]
+    public async Task<string> SetLineAsync(
+        [Description("Absolute path to the source file.")] string sourcePath,
+        [Description("Line number (1-based) to break on.")] int line,
+        [Description("Optional expression — break only when this evaluates to true.")] string? condition = null,
+        [Description("Optional hit count expression (e.g. \">5\") — break only on the Nth+ hit.")] string? hitCondition = null,
+        [Description("If set, makes this a logpoint (tracepoint): the message is logged and execution continues without pausing. Use {expr} interpolation.")] string? logMessage = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var bp = await _manager.AddLineBreakpointAsync(
+                sourcePath, line, condition, hitCondition, logMessage, ct).ConfigureAwait(false);
+            return ToolResults.Serialize(new { success = true, breakpoint = bp });
+        }
+        catch (Exception ex) { return ToolResults.Err(ex); }
+    }
+
+    [McpServerTool(Name = "breakpoint_set_function")]
+    [Description("Set a breakpoint on a function by symbol name (e.g. \"Namespace.Class.Method\").")]
+    public async Task<string> SetFunctionAsync(
+        [Description("Fully-qualified function name to break on.")] string functionName,
+        [Description("Optional condition expression.")] string? condition = null,
+        [Description("Optional hit count expression.")] string? hitCondition = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var bp = await _manager.AddFunctionBreakpointAsync(functionName, condition, hitCondition, ct)
+                .ConfigureAwait(false);
+            return ToolResults.Serialize(new { success = true, breakpoint = bp });
+        }
+        catch (Exception ex) { return ToolResults.Err(ex); }
+    }
+
+    [McpServerTool(Name = "breakpoint_remove")]
+    [Description("Remove a breakpoint by its id (line or function).")]
+    public async Task<string> RemoveAsync(
+        [Description("Breakpoint id returned from breakpoint_set or breakpoint_set_function.")] string id,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var removed = await _manager.RemoveBreakpointAsync(id, ct).ConfigureAwait(false);
+            return ToolResults.Serialize(new { success = true, removed });
+        }
+        catch (Exception ex) { return ToolResults.Err(ex); }
+    }
+
+    [McpServerTool(Name = "breakpoint_list")]
+    [Description("List all currently set breakpoints (line, function, and exception filters).")]
+    public string List()
+    {
+        try
+        {
+            var snap = _manager.ListBreakpoints();
+            return ToolResults.Serialize(new
+            {
+                success = true,
+                line = snap.Line,
+                function = snap.Function,
+                exceptionFilters = snap.ExceptionFilters,
+            });
+        }
+        catch (Exception ex) { return ToolResults.Err(ex); }
+    }
+
+    [McpServerTool(Name = "breakpoint_set_exception")]
+    [Description("Set the active exception breakpoint filters. Pass [] to clear. Common netcoredbg filters: \"all\", \"user-unhandled\".")]
+    public async Task<string> SetExceptionAsync(
+        [Description("Filter names. Empty array clears exception breakpoints.")] string[] filters,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            await _manager.SetExceptionFiltersAsync(filters ?? Array.Empty<string>(), ct).ConfigureAwait(false);
+            return ToolResults.Serialize(new { success = true, exceptionFilters = filters });
+        }
+        catch (Exception ex) { return ToolResults.Err(ex); }
+    }
+}

--- a/src/AspNetCoreDebuggerMcp/Tools/DiagnosticsTools.cs
+++ b/src/AspNetCoreDebuggerMcp/Tools/DiagnosticsTools.cs
@@ -1,0 +1,51 @@
+using System.ComponentModel;
+using AspNetCoreDebuggerMcp.Debugging;
+using ModelContextProtocol.Server;
+
+namespace AspNetCoreDebuggerMcp.Tools;
+
+[McpServerToolType]
+public sealed class DiagnosticsTools
+{
+    private const int DefaultTopFramesPerThread = 10;
+
+    private readonly DebugSessionManager _manager;
+
+    public DiagnosticsTools(DebugSessionManager manager) => _manager = manager;
+
+    [McpServerTool(Name = "hang_analyze")]
+    [Description("Diagnose why an application appears stuck. Auto-pauses if running, lists all threads, fetches the top frames of each, and classifies each thread's blocking pattern (Monitor / WaitHandle / Semaphore / Task / Thread.Join / Thread.Sleep / async await). Leaves the session paused so you can inspect further.")]
+    public async Task<string> HangAnalyzeAsync(
+        [Description("Top frames per thread to fetch. Default 10.")] int? topFramesPerThread = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var analysis = await _manager.HangAnalyzeAsync(
+                topFramesPerThread ?? DefaultTopFramesPerThread, ct).ConfigureAwait(false);
+            return ToolResults.Serialize(new
+            {
+                success = true,
+                blockedCount = analysis.BlockedCount,
+                cycleDetectionAvailable = analysis.CycleDetectionAvailable,
+                notes = analysis.Notes,
+                threads = analysis.Threads,
+            });
+        }
+        catch (Exception ex) { return ToolResults.Err(ex); }
+    }
+
+    [McpServerTool(Name = "process_read_output")]
+    [Description("Drain buffered output (stdout/stderr) from the debuggee since the previous call. Returns the lines collected and removes them from the buffer.")]
+    public string ProcessReadOutput(
+        [Description("Filter by category: \"stdout\", \"stderr\", \"console\", or omit for all.")] string? category = null,
+        [Description("Maximum lines to drain in this call.")] int? maxLines = null)
+    {
+        try
+        {
+            var lines = _manager.DrainOutput(category, maxLines);
+            return ToolResults.Serialize(new { success = true, lines });
+        }
+        catch (Exception ex) { return ToolResults.Err(ex); }
+    }
+}

--- a/src/AspNetCoreDebuggerMcp/Tools/ExecutionTools.cs
+++ b/src/AspNetCoreDebuggerMcp/Tools/ExecutionTools.cs
@@ -57,7 +57,7 @@ public sealed class ExecutionTools
     }
 
     [McpServerTool(Name = "breakpoint_wait")]
-    [Description("Block until the debuggee hits a breakpoint, completes a step, or otherwise stops. Returns the stop info.")]
+    [Description("Block until the debuggee hits a breakpoint, completes a step, or otherwise stops. Returns the stop info plus auto-context: the topmost stack frame and a source snippet around the stop.")]
     public async Task<string> WaitAsync(
         [Description("Maximum seconds to wait. Defaults to 30.")] int? timeoutSeconds = null,
         CancellationToken ct = default)
@@ -72,6 +72,8 @@ public sealed class ExecutionTools
                 stop = result.Stop,
                 state = result.Session.State,
                 processId = result.Session.ProcessId,
+                topFrame = result.TopFrame,
+                snippet = result.Snippet,
             });
         }
         catch (OperationCanceledException)

--- a/src/AspNetCoreDebuggerMcp/Tools/ExecutionTools.cs
+++ b/src/AspNetCoreDebuggerMcp/Tools/ExecutionTools.cs
@@ -1,0 +1,83 @@
+using System.ComponentModel;
+using AspNetCoreDebuggerMcp.Debugging;
+using ModelContextProtocol.Server;
+
+namespace AspNetCoreDebuggerMcp.Tools;
+
+[McpServerToolType]
+public sealed class ExecutionTools
+{
+    private const int DefaultWaitTimeoutSeconds = 30;
+
+    private readonly DebugSessionManager _manager;
+
+    public ExecutionTools(DebugSessionManager manager) => _manager = manager;
+
+    [McpServerTool(Name = "debug_continue")]
+    [Description("Resume execution of the debuggee. Defaults to the last-stopped thread.")]
+    public async Task<string> ContinueAsync(
+        [Description("Thread id to continue. If omitted, uses the last thread that stopped.")] int? threadId = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var snap = await _manager.ContinueAsync(threadId, ct).ConfigureAwait(false);
+            return ToolResults.Serialize(new { success = true, state = snap.State, processId = snap.ProcessId });
+        }
+        catch (Exception ex) { return ToolResults.Err(ex); }
+    }
+
+    [McpServerTool(Name = "debug_pause")]
+    [Description("Pause the debuggee. Requires a thread id; defaults to the last-stopped thread if known.")]
+    public async Task<string> PauseAsync(
+        [Description("Thread id to pause. If omitted, uses the last thread that stopped.")] int? threadId = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var snap = await _manager.PauseAsync(threadId, ct).ConfigureAwait(false);
+            return ToolResults.Serialize(new { success = true, state = snap.State });
+        }
+        catch (Exception ex) { return ToolResults.Err(ex); }
+    }
+
+    [McpServerTool(Name = "debug_step")]
+    [Description("Single-step the debuggee. Kind: \"in\" (step into), \"over\" (step over), \"out\" (step out).")]
+    public async Task<string> StepAsync(
+        [Description("Step kind: \"in\", \"over\", or \"out\".")] string kind,
+        [Description("Thread id to step. If omitted, uses the last thread that stopped.")] int? threadId = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var snap = await _manager.StepAsync(kind, threadId, ct).ConfigureAwait(false);
+            return ToolResults.Serialize(new { success = true, state = snap.State });
+        }
+        catch (Exception ex) { return ToolResults.Err(ex); }
+    }
+
+    [McpServerTool(Name = "breakpoint_wait")]
+    [Description("Block until the debuggee hits a breakpoint, completes a step, or otherwise stops. Returns the stop info.")]
+    public async Task<string> WaitAsync(
+        [Description("Maximum seconds to wait. Defaults to 30.")] int? timeoutSeconds = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var timeout = TimeSpan.FromSeconds(timeoutSeconds ?? DefaultWaitTimeoutSeconds);
+            var result = await _manager.WaitForStopAsync(timeout, ct).ConfigureAwait(false);
+            return ToolResults.Serialize(new
+            {
+                success = true,
+                stop = result.Stop,
+                state = result.Session.State,
+                processId = result.Session.ProcessId,
+            });
+        }
+        catch (OperationCanceledException)
+        {
+            return ToolResults.Serialize(new { success = false, error = "timeout", state = _manager.GetState().State });
+        }
+        catch (Exception ex) { return ToolResults.Err(ex); }
+    }
+}

--- a/src/AspNetCoreDebuggerMcp/Tools/InspectionTools.cs
+++ b/src/AspNetCoreDebuggerMcp/Tools/InspectionTools.cs
@@ -28,16 +28,17 @@ public sealed class InspectionTools
     }
 
     [McpServerTool(Name = "stacktrace_get")]
-    [Description("Get the call stack of a thread. Defaults to the last-stopped thread.")]
+    [Description("Get the call stack of a thread. By default async state-machine frames are flattened back to their original method names (e.g. UserService.<GetAsync>d__3.MoveNext → UserService.GetAsync) and BCL async infrastructure frames are hidden. Pass raw=true for the unmodified DAP frames.")]
     public async Task<string> StackTraceAsync(
         [Description("Thread id. Defaults to the last-stopped thread.")] int? threadId = null,
         [Description("Skip this many top frames (0 = include the topmost).")] int? startFrame = null,
         [Description("Maximum frames to return.")] int? levels = null,
+        [Description("If true, return raw DAP frames (no async flattening, no infrastructure filtering).")] bool raw = false,
         CancellationToken ct = default)
     {
         try
         {
-            var frames = await _manager.GetStackTraceAsync(threadId, startFrame, levels, ct).ConfigureAwait(false);
+            var frames = await _manager.GetStackTraceAsync(threadId, startFrame, levels, raw, ct).ConfigureAwait(false);
             return ToolResults.Serialize(new { success = true, frames });
         }
         catch (Exception ex) { return ToolResults.Err(ex); }

--- a/src/AspNetCoreDebuggerMcp/Tools/InspectionTools.cs
+++ b/src/AspNetCoreDebuggerMcp/Tools/InspectionTools.cs
@@ -1,0 +1,109 @@
+using System.ComponentModel;
+using AspNetCoreDebuggerMcp.Debugging;
+using ModelContextProtocol.Server;
+
+namespace AspNetCoreDebuggerMcp.Tools;
+
+[McpServerToolType]
+public sealed class InspectionTools
+{
+    private const int DefaultDepth = 1;
+    private const int DefaultMaxChildren = 50;
+    private const int DefaultAutopsyFrameCount = 20;
+
+    private readonly DebugSessionManager _manager;
+
+    public InspectionTools(DebugSessionManager manager) => _manager = manager;
+
+    [McpServerTool(Name = "threads_list")]
+    [Description("List all threads in the debuggee.")]
+    public async Task<string> ListThreadsAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var threads = await _manager.ListThreadsAsync(ct).ConfigureAwait(false);
+            return ToolResults.Serialize(new { success = true, threads });
+        }
+        catch (Exception ex) { return ToolResults.Err(ex); }
+    }
+
+    [McpServerTool(Name = "stacktrace_get")]
+    [Description("Get the call stack of a thread. Defaults to the last-stopped thread.")]
+    public async Task<string> StackTraceAsync(
+        [Description("Thread id. Defaults to the last-stopped thread.")] int? threadId = null,
+        [Description("Skip this many top frames (0 = include the topmost).")] int? startFrame = null,
+        [Description("Maximum frames to return.")] int? levels = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var frames = await _manager.GetStackTraceAsync(threadId, startFrame, levels, ct).ConfigureAwait(false);
+            return ToolResults.Serialize(new { success = true, frames });
+        }
+        catch (Exception ex) { return ToolResults.Err(ex); }
+    }
+
+    [McpServerTool(Name = "variables_get")]
+    [Description("Get variables for a stack frame. Defaults to the topmost frame of the last-stopped thread. Recursively expands compound values up to `depth` levels and truncates each level at `maxChildren`.")]
+    public async Task<string> VariablesAsync(
+        [Description("Frame id from stacktrace_get. Defaults to the topmost frame of the last-stopped thread.")] int? frameId = null,
+        [Description("Recursive expansion depth. 1 = just the top-level variables (default). 2 = expand one level into compound types. Higher = deeper.")] int? depth = null,
+        [Description("Maximum children to return at each level. Default 50.")] int? maxChildren = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var scopes = await _manager.GetScopesAsync(
+                frameId, depth ?? DefaultDepth, maxChildren ?? DefaultMaxChildren, ct).ConfigureAwait(false);
+            return ToolResults.Serialize(new { success = true, scopes });
+        }
+        catch (Exception ex) { return ToolResults.Err(ex); }
+    }
+
+    [McpServerTool(Name = "evaluate")]
+    [Description("Evaluate a C# expression in the context of a stack frame. Returns the result as a string plus a variablesReference if the result is a compound value.")]
+    public async Task<string> EvaluateAsync(
+        [Description("Expression to evaluate (e.g. \"user.Id\", \"items.Count\").")] string expression,
+        [Description("Frame id from stacktrace_get. Defaults to the global (no-frame) context.")] int? frameId = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var result = await _manager.EvaluateAsync(expression, frameId, ct).ConfigureAwait(false);
+            return ToolResults.Serialize(new { success = true, result });
+        }
+        catch (Exception ex) { return ToolResults.Err(ex); }
+    }
+
+    [McpServerTool(Name = "variables_set")]
+    [Description("Set the value of a variable or any lvalue expression (e.g. \"userId\" or \"user.Name\"). The agent can use this to test fixes by mutating state mid-run.")]
+    public async Task<string> SetVariableAsync(
+        [Description("The lvalue expression to assign to (e.g. \"userId\", \"user.Name\").")] string expression,
+        [Description("The new value as a C# expression (e.g. \"42\", \"\\\"hello\\\"\").")] string value,
+        [Description("Frame id from stacktrace_get. Defaults to the global (no-frame) context.")] int? frameId = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var result = await _manager.SetExpressionAsync(expression, value, frameId, ct).ConfigureAwait(false);
+            return ToolResults.Serialize(new { success = true, result });
+        }
+        catch (Exception ex) { return ToolResults.Err(ex); }
+    }
+
+    [McpServerTool(Name = "exception_autopsy")]
+    [Description("Full exception context in one call: exception type + inner-exception chain + top stack frames + top frame's locals + source snippet around the throw. Call this when state.lastStop.reason == \"exception\".")]
+    public async Task<string> AutopsyAsync(
+        [Description("Thread id. Defaults to the last-stopped thread.")] int? threadId = null,
+        [Description("How many top stack frames to include. Default 20.")] int? frameCount = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var autopsy = await _manager.AutopsyAsync(
+                threadId, frameCount ?? DefaultAutopsyFrameCount, ct).ConfigureAwait(false);
+            return ToolResults.Serialize(new { success = true, autopsy });
+        }
+        catch (Exception ex) { return ToolResults.Err(ex); }
+    }
+}

--- a/src/AspNetCoreDebuggerMcp/Tools/SessionTools.cs
+++ b/src/AspNetCoreDebuggerMcp/Tools/SessionTools.cs
@@ -1,0 +1,83 @@
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using AspNetCoreDebuggerMcp.Debugging;
+using ModelContextProtocol.Server;
+
+namespace AspNetCoreDebuggerMcp.Tools;
+
+[McpServerToolType]
+public sealed class SessionTools
+{
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly DebugSessionManager _manager;
+
+    public SessionTools(DebugSessionManager manager) => _manager = manager;
+
+    [McpServerTool(Name = "debug_launch")]
+    [Description("Launch a .NET program under the debugger. Returns the resulting session state.")]
+    public async Task<string> DebugLaunchAsync(
+        [Description("Path to the .NET program to debug (.dll or apphost executable).")] string program,
+        [Description("Command-line arguments to pass to the program.")] string[]? args = null,
+        [Description("Working directory for the program (defaults to the program's directory).")] string? cwd = null,
+        [Description("If true, the program pauses at entry instead of running until the first breakpoint.")] bool stopAtEntry = false,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var snap = await _manager.LaunchAsync(program, args, cwd, stopAtEntry, ct).ConfigureAwait(false);
+            return Ok(snap);
+        }
+        catch (Exception ex) { return Err(ex); }
+    }
+
+    [McpServerTool(Name = "debug_attach")]
+    [Description("Attach the debugger to an already-running .NET process by PID.")]
+    public async Task<string> DebugAttachAsync(
+        [Description("System process id (PID) of the .NET process to attach to.")] int processId,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var snap = await _manager.AttachAsync(processId, ct).ConfigureAwait(false);
+            return Ok(snap);
+        }
+        catch (Exception ex) { return Err(ex); }
+    }
+
+    [McpServerTool(Name = "debug_disconnect")]
+    [Description("Disconnect the debugger and terminate the debuggee.")]
+    public async Task<string> DebugDisconnectAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var snap = await _manager.DisconnectAsync(ct).ConfigureAwait(false);
+            return Ok(snap);
+        }
+        catch (Exception ex) { return Err(ex); }
+    }
+
+    [McpServerTool(Name = "debug_state")]
+    [Description("Return the current debug session state, including process id and last stop info.")]
+    public string DebugState()
+    {
+        try { return Ok(_manager.GetState()); }
+        catch (Exception ex) { return Err(ex); }
+    }
+
+    private static string Ok(SessionSnapshot snap) => JsonSerializer.Serialize(new
+    {
+        success = true,
+        state = snap.State,
+        processId = snap.ProcessId,
+        lastStop = snap.LastStop,
+    }, JsonOpts);
+
+    private static string Err(Exception ex)
+        => JsonSerializer.Serialize(new { success = false, error = ex.Message }, JsonOpts);
+}

--- a/src/AspNetCoreDebuggerMcp/Tools/ToolResults.cs
+++ b/src/AspNetCoreDebuggerMcp/Tools/ToolResults.cs
@@ -1,0 +1,19 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AspNetCoreDebuggerMcp.Tools;
+
+/// Shared JSON serializer + standard error envelope for MCP tool results.
+internal static class ToolResults
+{
+    public static readonly JsonSerializerOptions Json = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    public static string Serialize<T>(T value) => JsonSerializer.Serialize(value, Json);
+
+    public static string Err(Exception ex)
+        => JsonSerializer.Serialize(new { success = false, error = ex.Message }, Json);
+}

--- a/src/AspNetCoreDebuggerMcp/Tools/ToolResults.cs
+++ b/src/AspNetCoreDebuggerMcp/Tools/ToolResults.cs
@@ -10,6 +10,7 @@ internal static class ToolResults
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
     };
 
     public static string Serialize<T>(T value) => JsonSerializer.Serialize(value, Json);

--- a/tests/AspNetCoreDebuggerMcp.Tests/AspNetCoreDebuggerMcp.Tests.csproj
+++ b/tests/AspNetCoreDebuggerMcp.Tests/AspNetCoreDebuggerMcp.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AspNetCoreDebuggerMcp\AspNetCoreDebuggerMcp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/AspNetCoreDebuggerMcp.Tests/Breakpoints/BreakpointRegistryTests.cs
+++ b/tests/AspNetCoreDebuggerMcp.Tests/Breakpoints/BreakpointRegistryTests.cs
@@ -1,0 +1,102 @@
+using AspNetCoreDebuggerMcp.Breakpoints;
+
+namespace AspNetCoreDebuggerMcp.Tests.Breakpoints;
+
+public class BreakpointRegistryTests
+{
+    [Fact]
+    public void AddLine_AssignsIdAndAppearsInSnapshot()
+    {
+        var r = new BreakpointRegistry();
+        var bp = r.AddLine("/repo/Program.cs", 5, null, null, null);
+
+        Assert.StartsWith("bp-", bp.Id);
+        Assert.False(bp.Verified);
+
+        var snap = r.Snapshot();
+        Assert.Single(snap.Line);
+        Assert.Equal(bp.Id, snap.Line[0].Id);
+    }
+
+    [Fact]
+    public void Remove_RemovesAndReturnsKind()
+    {
+        var r = new BreakpointRegistry();
+        var l = r.AddLine("/x.cs", 1, null, null, null);
+        var f = r.AddFunction("Foo.Bar", null, null);
+
+        Assert.Equal(BreakpointKind.Line, r.Remove(l.Id));
+        Assert.Equal(BreakpointKind.Function, r.Remove(f.Id));
+        Assert.Null(r.Remove("bp-deadbeef"));
+
+        var snap = r.Snapshot();
+        Assert.Empty(snap.Line);
+        Assert.Empty(snap.Function);
+    }
+
+    [Fact]
+    public void ForSource_FiltersByPathExactly()
+    {
+        var r = new BreakpointRegistry();
+        r.AddLine("/a.cs", 1, null, null, null);
+        r.AddLine("/a.cs", 2, null, null, null);
+        r.AddLine("/b.cs", 1, null, null, null);
+
+        Assert.Equal(2, r.ForSource("/a.cs").Count);
+        Assert.Single(r.ForSource("/b.cs"));
+        Assert.Empty(r.ForSource("/c.cs"));
+    }
+
+    [Fact]
+    public void Sources_ReturnsDistinctPaths()
+    {
+        var r = new BreakpointRegistry();
+        r.AddLine("/a.cs", 1, null, null, null);
+        r.AddLine("/a.cs", 2, null, null, null);
+        r.AddLine("/b.cs", 1, null, null, null);
+
+        var sources = r.Sources();
+        Assert.Equal(2, sources.Count);
+        Assert.Contains("/a.cs", sources);
+        Assert.Contains("/b.cs", sources);
+    }
+
+    [Fact]
+    public void UpdateLine_SetsVerifiedAndAdapterId()
+    {
+        var r = new BreakpointRegistry();
+        var bp = r.AddLine("/a.cs", 1, null, null, null);
+
+        r.UpdateLine(bp.Id, verified: true, adapterId: 42);
+
+        var updated = r.Snapshot().Line.Single();
+        Assert.True(updated.Verified);
+        Assert.Equal(42, updated.AdapterId);
+    }
+
+    [Fact]
+    public void UpdateLineByAdapterId_FlipsVerifiedForMatchingBreakpoint()
+    {
+        var r = new BreakpointRegistry();
+        var a = r.AddLine("/a.cs", 1, null, null, null);
+        var b = r.AddLine("/a.cs", 2, null, null, null);
+        r.UpdateLine(a.Id, false, adapterId: 7);
+        r.UpdateLine(b.Id, false, adapterId: 8);
+
+        r.UpdateLineByAdapterId(7, verified: true);
+
+        var snap = r.Snapshot().Line;
+        Assert.True(snap.Single(bp => bp.AdapterId == 7).Verified);
+        Assert.False(snap.Single(bp => bp.AdapterId == 8).Verified);
+    }
+
+    [Fact]
+    public void SetExceptionFilters_ReplacesFullSet()
+    {
+        var r = new BreakpointRegistry();
+        r.SetExceptionFilters(new[] { "all" });
+        r.SetExceptionFilters(new[] { "user-unhandled" });
+
+        Assert.Equal(new[] { "user-unhandled" }, r.Snapshot().ExceptionFilters);
+    }
+}

--- a/tests/AspNetCoreDebuggerMcp.Tests/Dap/DapClientTests.cs
+++ b/tests/AspNetCoreDebuggerMcp.Tests/Dap/DapClientTests.cs
@@ -1,0 +1,81 @@
+using System.Text.Json;
+using AspNetCoreDebuggerMcp.Dap;
+
+namespace AspNetCoreDebuggerMcp.Tests.Dap;
+
+public class DapClientTests
+{
+    [Fact]
+    public async Task SendRequest_CompletesWhenResponseWithMatchingSeqArrives()
+    {
+        await using var client = new DapClient(Stream.Null, new MemoryStream());
+
+        var task = client.SendRequestAsync("initialize", null, CancellationToken.None);
+        Assert.False(task.IsCompleted);
+
+        client.HandleInbound(new DapMessage
+        {
+            Type = "response",
+            RequestSeq = 1,
+            Success = true,
+            Command = "initialize",
+        });
+
+        var response = await task;
+        Assert.True(response.Success);
+        Assert.Equal("initialize", response.Command);
+    }
+
+    [Fact]
+    public async Task SendRequest_WritesFramedJsonWithIncrementingSeqAndCommand()
+    {
+        var output = new MemoryStream();
+        await using var client = new DapClient(Stream.Null, output);
+
+        _ = client.SendRequestAsync("initialize", null, CancellationToken.None);
+        _ = client.SendRequestAsync("launch", new { program = "/tmp/x.dll" }, CancellationToken.None);
+
+        await Task.Delay(50);
+
+        output.Position = 0;
+        var a = await DapProtocol.ReadMessageAsync(output, CancellationToken.None);
+        var b = await DapProtocol.ReadMessageAsync(output, CancellationToken.None);
+
+        using var docA = JsonDocument.Parse(a!);
+        using var docB = JsonDocument.Parse(b!);
+
+        Assert.Equal("request", docA.RootElement.GetProperty("type").GetString());
+        Assert.Equal("initialize", docA.RootElement.GetProperty("command").GetString());
+        Assert.Equal(1, docA.RootElement.GetProperty("seq").GetInt32());
+
+        Assert.Equal("launch", docB.RootElement.GetProperty("command").GetString());
+        Assert.Equal(2, docB.RootElement.GetProperty("seq").GetInt32());
+        Assert.Equal("/tmp/x.dll",
+            docB.RootElement.GetProperty("arguments").GetProperty("program").GetString());
+    }
+
+    [Fact]
+    public async Task EventReceived_FiresForEventMessages()
+    {
+        await using var client = new DapClient(Stream.Null, new MemoryStream());
+        DapMessage? captured = null;
+        client.EventReceived += m => captured = m;
+
+        client.HandleInbound(new DapMessage { Type = "event", Event = "initialized" });
+
+        Assert.NotNull(captured);
+        Assert.Equal("initialized", captured!.Event);
+    }
+
+    [Fact]
+    public async Task SendRequest_CancelsWhenTokenCancels()
+    {
+        await using var client = new DapClient(Stream.Null, new MemoryStream());
+        using var cts = new CancellationTokenSource();
+
+        var task = client.SendRequestAsync("initialize", null, cts.Token);
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+    }
+}

--- a/tests/AspNetCoreDebuggerMcp.Tests/Dap/DapProtocolTests.cs
+++ b/tests/AspNetCoreDebuggerMcp.Tests/Dap/DapProtocolTests.cs
@@ -1,0 +1,67 @@
+using System.Text;
+using AspNetCoreDebuggerMcp.Dap;
+
+namespace AspNetCoreDebuggerMcp.Tests.Dap;
+
+public class DapProtocolTests
+{
+    [Fact]
+    public async Task WriteThenRead_RoundTripsSingleMessage()
+    {
+        using var stream = new MemoryStream();
+        const string json = """{"seq":1,"type":"request","command":"initialize"}""";
+
+        await DapProtocol.WriteMessageAsync(stream, json, CancellationToken.None);
+        stream.Position = 0;
+        var read = await DapProtocol.ReadMessageAsync(stream, CancellationToken.None);
+
+        Assert.Equal(json, read);
+    }
+
+    [Fact]
+    public async Task ReadMessageAsync_HandlesTwoFramedMessagesBackToBack()
+    {
+        using var stream = new MemoryStream();
+        const string a = """{"seq":1,"type":"response"}""";
+        const string b = """{"seq":2,"type":"event","event":"initialized"}""";
+
+        await DapProtocol.WriteMessageAsync(stream, a, CancellationToken.None);
+        await DapProtocol.WriteMessageAsync(stream, b, CancellationToken.None);
+        stream.Position = 0;
+
+        var first = await DapProtocol.ReadMessageAsync(stream, CancellationToken.None);
+        var second = await DapProtocol.ReadMessageAsync(stream, CancellationToken.None);
+
+        Assert.Equal(a, first);
+        Assert.Equal(b, second);
+    }
+
+    [Fact]
+    public async Task ReadMessageAsync_ReturnsNullOnCleanEndOfStream()
+    {
+        using var stream = new MemoryStream(Array.Empty<byte>());
+        var read = await DapProtocol.ReadMessageAsync(stream, CancellationToken.None);
+        Assert.Null(read);
+    }
+
+    [Fact]
+    public async Task ReadMessageAsync_ThrowsOnTruncatedBody()
+    {
+        var bytes = Encoding.ASCII.GetBytes("Content-Length: 100\r\n\r\nhello");
+        using var stream = new MemoryStream(bytes);
+        await Assert.ThrowsAsync<EndOfStreamException>(() =>
+            DapProtocol.ReadMessageAsync(stream, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ReadMessageAsync_HandlesUtf8MultiByteBody()
+    {
+        using var stream = new MemoryStream();
+        const string json = """{"msg":"héllo →"}""";
+        await DapProtocol.WriteMessageAsync(stream, json, CancellationToken.None);
+        stream.Position = 0;
+
+        var read = await DapProtocol.ReadMessageAsync(stream, CancellationToken.None);
+        Assert.Equal(json, read);
+    }
+}

--- a/tests/AspNetCoreDebuggerMcp.Tests/Debugging/SessionStateMachineTests.cs
+++ b/tests/AspNetCoreDebuggerMcp.Tests/Debugging/SessionStateMachineTests.cs
@@ -1,0 +1,53 @@
+using AspNetCoreDebuggerMcp.Debugging;
+
+namespace AspNetCoreDebuggerMcp.Tests.Debugging;
+
+public class SessionStateMachineTests
+{
+    [Fact]
+    public void DefaultInitialState_IsInitializing()
+    {
+        var sm = new SessionStateMachine();
+        Assert.Equal(SessionState.Initializing, sm.State);
+    }
+
+    [Fact]
+    public void Transition_MovesToTargetState()
+    {
+        var sm = new SessionStateMachine();
+        sm.Transition(SessionState.Configuring);
+        Assert.Equal(SessionState.Configuring, sm.State);
+        sm.Transition(SessionState.Running);
+        Assert.Equal(SessionState.Running, sm.State);
+    }
+
+    [Fact]
+    public void OnStopped_MovesRunningToPaused()
+    {
+        var sm = new SessionStateMachine(SessionState.Running);
+        sm.OnStopped();
+        Assert.Equal(SessionState.Paused, sm.State);
+    }
+
+    [Fact]
+    public void OnContinued_MovesPausedToRunning()
+    {
+        var sm = new SessionStateMachine(SessionState.Paused);
+        sm.OnContinued();
+        Assert.Equal(SessionState.Running, sm.State);
+    }
+
+    [Fact]
+    public void OnTerminated_IsSticky_LateEventsCannotResurrect()
+    {
+        var sm = new SessionStateMachine(SessionState.Running);
+        sm.OnTerminated();
+        Assert.Equal(SessionState.Terminated, sm.State);
+
+        sm.OnStopped();
+        sm.OnContinued();
+        sm.Transition(SessionState.Running);
+
+        Assert.Equal(SessionState.Terminated, sm.State);
+    }
+}

--- a/tests/AspNetCoreDebuggerMcp.Tests/Debugging/StopWaiterTests.cs
+++ b/tests/AspNetCoreDebuggerMcp.Tests/Debugging/StopWaiterTests.cs
@@ -1,0 +1,80 @@
+using AspNetCoreDebuggerMcp.Debugging;
+
+namespace AspNetCoreDebuggerMcp.Tests.Debugging;
+
+public class StopWaiterTests
+{
+    [Fact]
+    public async Task SetStop_CompletesPendingWait()
+    {
+        var w = new StopWaiter();
+        var wait = w.WaitAsync(CancellationToken.None);
+        Assert.False(wait.IsCompleted);
+
+        w.SetStop(new StopInfo("breakpoint", 1, null));
+        var info = await wait;
+        Assert.Equal("breakpoint", info.Reason);
+    }
+
+    [Fact]
+    public async Task Reset_BeforeStop_NextWaitSeesNewStop()
+    {
+        var w = new StopWaiter();
+
+        // First cycle: stop arrives, wait returns.
+        w.SetStop(new StopInfo("entry", 1, null));
+        var first = await w.WaitAsync(CancellationToken.None);
+        Assert.Equal("entry", first.Reason);
+
+        // Reset to discard the completed TCS, then wait again.
+        w.Reset();
+        var second = w.WaitAsync(CancellationToken.None);
+        Assert.False(second.IsCompleted);
+
+        w.SetStop(new StopInfo("breakpoint", 2, null));
+        Assert.Equal("breakpoint", (await second).Reason);
+    }
+
+    [Fact]
+    public async Task Terminate_FaultsPendingWait()
+    {
+        var w = new StopWaiter();
+        var wait = w.WaitAsync(CancellationToken.None);
+
+        w.Terminate();
+
+        await Assert.ThrowsAsync<DebugException>(() => wait);
+    }
+
+    [Fact]
+    public void Terminate_SuppressesReset()
+    {
+        var w = new StopWaiter();
+        w.Terminate();
+        w.Reset();   // should not throw or revive
+        // A new wait observes the terminated faulted TCS.
+        var t = w.WaitAsync(CancellationToken.None);
+        Assert.True(t.IsFaulted);
+    }
+
+    [Fact]
+    public async Task SetStop_FirstWinsUntilReset()
+    {
+        var w = new StopWaiter();
+        w.SetStop(new StopInfo("first", 1, null));
+        w.SetStop(new StopInfo("second", 1, null));   // ignored — first already won
+
+        var info = await w.WaitAsync(CancellationToken.None);
+        Assert.Equal("first", info.Reason);
+    }
+
+    [Fact]
+    public async Task Wait_CancelsWhenTokenCancels()
+    {
+        var w = new StopWaiter();
+        using var cts = new CancellationTokenSource();
+        var wait = w.WaitAsync(cts.Token);
+        cts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => wait);
+    }
+}

--- a/tests/AspNetCoreDebuggerMcp.Tests/Diagnostics/ThreadAnalyzerTests.cs
+++ b/tests/AspNetCoreDebuggerMcp.Tests/Diagnostics/ThreadAnalyzerTests.cs
@@ -1,0 +1,60 @@
+using AspNetCoreDebuggerMcp.Diagnostics;
+
+namespace AspNetCoreDebuggerMcp.Tests.Diagnostics;
+
+public class ThreadAnalyzerTests
+{
+    [Theory]
+    [InlineData("System.Threading.Monitor.Wait(object)", BlockingKind.BlockedOnMonitor)]
+    [InlineData("System.Threading.Monitor.Enter(object)", BlockingKind.BlockedOnMonitor)]
+    [InlineData("System.Threading.SemaphoreSlim.Wait()", BlockingKind.BlockedOnSemaphore)]
+    [InlineData("System.Threading.WaitHandle.WaitOne()", BlockingKind.BlockedOnWaitHandle)]
+    [InlineData("System.Threading.ManualResetEvent.WaitOne()", BlockingKind.BlockedOnWaitHandle)]
+    [InlineData("System.Threading.Tasks.Task.Wait()", BlockingKind.BlockedOnTask)]
+    [InlineData("System.Runtime.CompilerServices.TaskAwaiter.GetResult()", BlockingKind.BlockedOnTask)]
+    [InlineData("System.Threading.Thread.Join()", BlockingKind.BlockedOnThreadJoin)]
+    [InlineData("System.Threading.Thread.Sleep(int)", BlockingKind.Sleeping)]
+    [InlineData("System.Runtime.CompilerServices.AsyncTaskMethodBuilder.AwaitUnsafeOnCompleted", BlockingKind.AwaitingAsync)]
+    [InlineData("MyApp.Program.<Main>$(string[])", BlockingKind.Running)]
+    public void Classify_FromTopFrameName(string topFrame, BlockingKind expected)
+    {
+        Assert.Equal(expected, ThreadAnalyzer.Classify(new[] { topFrame }));
+    }
+
+    [Fact]
+    public void Classify_PrefersTopmostFrame()
+    {
+        // Monitor.Wait is deeper in stack, but Sleep is on top → Sleeping wins.
+        var frames = new[]
+        {
+            "System.Threading.Thread.Sleep(int)",
+            "System.Threading.Monitor.Wait(object)",
+            "MyApp.Worker.Run()",
+        };
+        Assert.Equal(BlockingKind.Sleeping, ThreadAnalyzer.Classify(frames));
+    }
+
+    [Fact]
+    public void Analyze_CountsBlockedThreadsAndAddsCycleNote()
+    {
+        var threads = new[]
+        {
+            new ThreadHangInfo(1, "Main", BlockingKind.Running, Array.Empty<string>()),
+            new ThreadHangInfo(2, "Worker1", BlockingKind.BlockedOnMonitor, Array.Empty<string>()),
+            new ThreadHangInfo(3, "Worker2", BlockingKind.BlockedOnTask, Array.Empty<string>()),
+        };
+        var result = ThreadAnalyzer.Analyze(threads);
+        Assert.Equal(2, result.BlockedCount);
+        Assert.False(result.CycleDetectionAvailable);
+        Assert.Contains("Cycle detection", result.Notes);
+    }
+
+    [Fact]
+    public void Analyze_NoBlockedThreads_HasNotice()
+    {
+        var threads = new[] { new ThreadHangInfo(1, "Main", BlockingKind.Running, Array.Empty<string>()) };
+        var result = ThreadAnalyzer.Analyze(threads);
+        Assert.Equal(0, result.BlockedCount);
+        Assert.Contains("No threads appear blocked", result.Notes);
+    }
+}

--- a/tests/AspNetCoreDebuggerMcp.Tests/Inspection/AsyncStackFlattenerTests.cs
+++ b/tests/AspNetCoreDebuggerMcp.Tests/Inspection/AsyncStackFlattenerTests.cs
@@ -1,0 +1,76 @@
+using AspNetCoreDebuggerMcp.Inspection;
+
+namespace AspNetCoreDebuggerMcp.Tests.Inspection;
+
+public class AsyncStackFlattenerTests
+{
+    [Theory]
+    [InlineData("MyApp.UserService.<GetUserAsync>d__3.MoveNext()", "MyApp.UserService.GetUserAsync()")]
+    [InlineData("MyApp.Foo.<DoAsync>d__7.MoveNext", "MyApp.Foo.DoAsync")]
+    [InlineData("MyApp.Controllers.UserController.<GetAsync>d__5.MoveNext()", "MyApp.Controllers.UserController.GetAsync()")]
+    public void RewriteName_StateMachineToOriginal(string input, string expected)
+    {
+        Assert.Equal(expected, AsyncStackFlattener.RewriteName(input));
+    }
+
+    [Theory]
+    [InlineData("Program.<>c.<<Main>$>b__0_0()")]            // top-level lambda — NOT a state machine
+    [InlineData("MyApp.Foo.Bar()")]                            // ordinary method
+    [InlineData("MyApp.Foo.<>c__DisplayClass1_0.<Bar>b__0()")] // closure-class lambda
+    public void RewriteName_DoesNotTouchLambdasOrPlainMethods(string input)
+    {
+        Assert.Equal(input, AsyncStackFlattener.RewriteName(input));
+    }
+
+    [Theory]
+    [InlineData("System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.Start[TStateMachine](ref TStateMachine)", true)]
+    [InlineData("System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start", true)]
+    [InlineData("System.Threading.ExecutionContext.RunInternal(ExecutionContext, ContextCallback, object)", true)]
+    [InlineData("System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(IAsyncStateMachineBox, bool)", true)]
+    [InlineData("System.Threading.ThreadPoolWorkQueue.Dispatch()", true)]
+    [InlineData("MyApp.UserService.GetUserAsync()", false)]
+    [InlineData("System.Linq.Enumerable.Where[T](IEnumerable`1, Func`2)", false)]
+    public void IsInfrastructure_MatchesKnownFramesOnly(string name, bool expected)
+    {
+        Assert.Equal(expected, AsyncStackFlattener.IsInfrastructure(name));
+    }
+
+    [Fact]
+    public void Flatten_RewritesStateMachinesAndDropsInfrastructure()
+    {
+        var frames = new[]
+        {
+            new StackFrame(1, "MyApp.UserRepository.<GetByIdAsync>d__2.MoveNext()", "/repo.cs", 42, null),
+            new StackFrame(2, "System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.Start[T]", null, null, null),
+            new StackFrame(3, "MyApp.UserService.<GetUserAsync>d__3.MoveNext()", "/svc.cs", 17, null),
+            new StackFrame(4, "System.Threading.ExecutionContext.RunInternal", null, null, null),
+            new StackFrame(5, "MyApp.UserController.<GetAsync>d__5.MoveNext()", "/ctrl.cs", 9, null),
+        };
+
+        var flat = AsyncStackFlattener.Flatten(frames, hideInfrastructure: true);
+
+        Assert.Equal(3, flat.Count);
+        Assert.Equal("MyApp.UserRepository.GetByIdAsync()", flat[0].Name);
+        Assert.Equal("MyApp.UserService.GetUserAsync()", flat[1].Name);
+        Assert.Equal("MyApp.UserController.GetAsync()", flat[2].Name);
+        Assert.Equal(42, flat[0].Line);   // line numbers preserved
+        Assert.Equal(17, flat[1].Line);
+        Assert.Equal(9, flat[2].Line);
+    }
+
+    [Fact]
+    public void Flatten_HideInfrastructureFalse_KeepsAllFrames()
+    {
+        var frames = new[]
+        {
+            new StackFrame(1, "MyApp.UserService.<GetAsync>d__3.MoveNext()", null, null, null),
+            new StackFrame(2, "System.Threading.ExecutionContext.RunInternal", null, null, null),
+        };
+
+        var flat = AsyncStackFlattener.Flatten(frames, hideInfrastructure: false);
+
+        Assert.Equal(2, flat.Count);
+        Assert.Equal("MyApp.UserService.GetAsync()", flat[0].Name);              // still rewritten
+        Assert.Equal("System.Threading.ExecutionContext.RunInternal", flat[1].Name); // kept
+    }
+}

--- a/tests/AspNetCoreDebuggerMcp.Tests/Inspection/InspectionServiceTests.cs
+++ b/tests/AspNetCoreDebuggerMcp.Tests/Inspection/InspectionServiceTests.cs
@@ -1,0 +1,50 @@
+using AspNetCoreDebuggerMcp.Inspection;
+
+namespace AspNetCoreDebuggerMcp.Tests.Inspection;
+
+public class InspectionServiceTests
+{
+    [Fact]
+    public void TryReadSnippet_ReturnsLinesAroundHighlightWithMarker()
+    {
+        var path = Path.GetTempFileName();
+        File.WriteAllLines(path, new[] { "a", "b", "c", "d", "e", "f", "g" });
+        try
+        {
+            var snippet = InspectionService.TryReadSnippet(path, highlightLine: 4, radius: 2);
+
+            Assert.NotNull(snippet);
+            Assert.Equal(2, snippet!.StartLine);
+            Assert.Equal(6, snippet.EndLine);
+            Assert.Equal(4, snippet.HighlightLine);
+            Assert.Contains("→    4: d", snippet.Text);
+            Assert.Contains("     2: b", snippet.Text);
+            Assert.Contains("     6: f", snippet.Text);
+            Assert.DoesNotContain(": a", snippet.Text);
+            Assert.DoesNotContain(": g", snippet.Text);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void TryReadSnippet_ClampsToFileBoundaries()
+    {
+        var path = Path.GetTempFileName();
+        File.WriteAllLines(path, new[] { "one", "two", "three" });
+        try
+        {
+            var snippet = InspectionService.TryReadSnippet(path, highlightLine: 1, radius: 5);
+            Assert.NotNull(snippet);
+            Assert.Equal(1, snippet!.StartLine);
+            Assert.Equal(3, snippet.EndLine);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void TryReadSnippet_ReturnsNullForMissingFile()
+    {
+        var snippet = InspectionService.TryReadSnippet("/nonexistent/path/xyz.cs", 1);
+        Assert.Null(snippet);
+    }
+}


### PR DESCRIPTION
## Summary

- Builds the entire **aspnetcore-debugger-mcp** project: an MIT-licensed Model Context Protocol server that wraps `netcoredbg` over the Debug Adapter Protocol, giving AI agents 22 interactive .NET debugging tools (session, breakpoints, execution, inspection, exception autopsy, hang analysis, process output).
- 44 unit tests plus per-wave end-to-end smoke validation. **Final E2E proves the headline use case end-to-end:** agent launches a real ASP.NET Core Web API, sets a breakpoint inside a handler lambda, an HTTP request hits the BP mid-flight, agent inspects `name="world"` and evaluates `name.ToUpper()` → `"WORLD"` against the live frame, continues, HTTP 200 returns with the expected body — 0.3s total.
- Ships as a .NET tool (`PackAsTool`, produces `AspNetCoreDebuggerMcp.0.1.0-preview.nupkg`), with full README, a macOS arm64 `netcoredbg` build script, and GitHub Actions CI on Linux + macOS.

## What's in each commit

- `8eb6481` Wave 1 — hand-rolled DAP client (framing + correlation + event dispatch), netcoredbg process lifecycle, session state machine, the initialize/launch/configurationDone handshake. Tools: `debug_launch`, `debug_attach`, `debug_disconnect`, `debug_state`.
- `cb93be6` Wave 2 — BreakpointRegistry (DAP full-replacement semantics), StopWaiter for blocking waits. Tools: `breakpoint_set` (line/conditional/hit-count/logpoint), `breakpoint_set_function`, `breakpoint_remove`, `breakpoint_list`, `breakpoint_set_exception`, `debug_continue`, `debug_pause`, `debug_step`, `breakpoint_wait`.
- `56c2540` Wave 3 — InspectionService over DAP threads/stackTrace/scopes/variables/evaluate/setExpression/exceptionInfo; recursive variable expansion with depth + max-children truncation; `exception_autopsy` composite (exception chain + frames + locals + source snippet in one call); auto-context-on-stop on `breakpoint_wait`. Tools: `threads_list`, `stacktrace_get`, `variables_get`, `evaluate`, `variables_set`, `exception_autopsy`.
- `1ebdfe3` Wave 4 — ThreadAnalyzer + `hang_analyze` composite (auto-pause, classify each thread's blocking primitive); DAP `output` event buffering + `process_read_output`; data breakpoints wired through (netcoredbg currently returns E_NOTIMPL for `dataBreakpointInfo`, surfaced as a clean adapter-limitation error).
- `62ce0c4` Wave 5 — `.NET tool packaging metadata, full README with tool table + Claude Code/Desktop config snippets, `scripts/build-netcoredbg-macos-arm64.sh`, GitHub Actions CI workflow.

## Honest scope notes

- **`breakpoint_set_data` is adapter-limited.** netcoredbg returns `E_NOTIMPL` for `dataBreakpointInfo`. The tool is wired correctly and surfaces a clear error; another adapter (or a future netcoredbg) would just work.
- **`process_write_input` is not implemented.** DAP launch mode owns the debuggee's stdin; piping input would require a different launch architecture (we launch the process, netcoredbg attaches). Deferred — documented in the README's Known Limits.

## Test plan

- [ ] CI passes on Linux + macOS (`.github/workflows/ci.yml`)
- [ ] `dotnet build` — 0 warnings, 0 errors
- [ ] `dotnet test` — 44/44 pass
- [ ] `dotnet pack src/AspNetCoreDebuggerMcp -c Release -o nupkg` — package builds (~1.4 MB)
- [ ] (Optional, requires netcoredbg + the build script on macOS arm64) Install locally and debug a small Web API per the README example

Linear: MAG-39

🤖 Generated with [Claude Code](https://claude.com/claude-code)