### PR TITLE
Release workflow: GitHub Release → nupkg → NuGet.org (MAG-40)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release
+
+# Fires when you publish a GitHub Release from the UI (or via `gh release create`).
+# Tag convention is `v0.1.0-preview`, `v0.2.0`, etc. — the leading `v` is stripped to form
+# the NuGet package version. workflow_dispatch is provided for manual dry runs.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to pack (e.g. 0.1.0-preview). For dry runs.'
+        required: true
+        type: string
+      push_to_nuget:
+        description: 'Also push to NuGet.org? (workflow_dispatch only — release events always push if the secret is set)'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # required to upload the .nupkg as a release asset
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+          dotnet-quality: 'ga'
+
+      - name: Resolve version
+        id: ver
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          RELEASE_TAG:   ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "release" ]; then
+            v="${RELEASE_TAG#v}"
+          else
+            v="$INPUT_VERSION"
+          fi
+          if [ -z "$v" ]; then
+            echo "Could not resolve a version (empty)." >&2
+            exit 1
+          fi
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $v"
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build -c Release --no-restore /p:Version=${{ steps.ver.outputs.version }}
+
+      - name: Test
+        run: dotnet test -c Release --no-build --verbosity normal
+
+      - name: Pack
+        run: |
+          dotnet pack src/AspNetCoreDebuggerMcp -c Release --no-build \
+            -o nupkg /p:Version=${{ steps.ver.outputs.version }}
+
+      - name: Show pack output
+        run: ls -lh nupkg/
+
+      - name: Attach .nupkg to the GitHub Release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: nupkg/*.nupkg
+
+      - name: Push to NuGet.org
+        # Always run for release events; only run for workflow_dispatch if explicitly requested.
+        if: |
+          github.event_name == 'release' ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.push_to_nuget == 'true')
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          if [ -z "${NUGET_API_KEY:-}" ]; then
+            echo "::warning::NUGET_API_KEY secret is not set — skipping NuGet.org push."
+            echo "Add it at https://github.com/${{ github.repository }}/settings/secrets/actions"
+            exit 0
+          fi
+          dotnet nuget push nupkg/*.nupkg \
+            --api-key "$NUGET_API_KEY" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate

--- a/README.md
+++ b/README.md
@@ -56,37 +56,47 @@ composites on top — `exception_autopsy`, `stack_explore`, `hang_analyze`, and 
 
 ---
 
-## Install
+## Use it in 4 steps
 
-You need three things: the .NET 10 SDK, `netcoredbg`, and this tool.
+Once per machine: install prerequisites and the tool. Once per project: register it. Then just chat.
 
-**1. .NET 10 SDK** — [dotnet.microsoft.com/download](https://dotnet.microsoft.com/download).
+### Step 1 — Prerequisites *(once per machine)*
 
-**2. netcoredbg:**
+- **.NET 10 SDK** — [dotnet.microsoft.com/download](https://dotnet.microsoft.com/download)
+- **netcoredbg** — Samsung's MIT-licensed .NET debugger that this server drives:
 
-| Platform | Get it from |
-|---|---|
-| Linux x64 / arm64 | [Samsung release](https://github.com/Samsung/netcoredbg/releases) |
-| Windows x64 | [Samsung release](https://github.com/Samsung/netcoredbg/releases) |
-| macOS Intel (x64) | [Samsung release](https://github.com/Samsung/netcoredbg/releases) |
-| **macOS Apple Silicon (arm64)** | **No prebuilt — build with `scripts/build-netcoredbg-macos-arm64.sh`** |
+  | Platform | Get it from |
+  |---|---|
+  | Linux x64 / arm64 | [Samsung release](https://github.com/Samsung/netcoredbg/releases) |
+  | Windows x64 | [Samsung release](https://github.com/Samsung/netcoredbg/releases) |
+  | macOS Intel (x64) | [Samsung release](https://github.com/Samsung/netcoredbg/releases) |
+  | **macOS Apple Silicon (arm64)** | **No prebuilt — build with `scripts/build-netcoredbg-macos-arm64.sh`** |
+- **Claude Code** or **Claude Desktop** installed.
 
-Then point the server at it: `export NETCOREDBG_PATH=/absolute/path/to/netcoredbg` (or put it on
-`PATH`, or place it next to the tool's assembly).
-
-**3. The MCP server:**
+### Step 2 — Install the MCP server *(once per machine)*
 
 ```bash
 dotnet tool install -g AspNetCoreDebuggerMcp --prerelease
 ```
 
-Verify: `NETCOREDBG_PATH=/path/to/netcoredbg aspnetcore-debugger-mcp` should start without errors.
+That puts the `aspnetcore-debugger-mcp` binary on your `PATH`. Verify:
 
----
+```bash
+NETCOREDBG_PATH=/path/to/netcoredbg aspnetcore-debugger-mcp
+# starts and idles on stdin; Ctrl-C to exit
+```
 
-## Configure your MCP client
+### Step 3 — Register it with your MCP client *(once per project, or globally)*
 
-### Claude Code (`.mcp.json`)
+**Claude Code** — either run:
+
+```bash
+claude mcp add aspnetcore-debugger \
+  -e NETCOREDBG_PATH=/path/to/netcoredbg \
+  -- aspnetcore-debugger-mcp
+```
+
+or edit `.mcp.json` (project) / `~/.claude.json` (global) directly:
 
 ```json
 {
@@ -99,9 +109,15 @@ Verify: `NETCOREDBG_PATH=/path/to/netcoredbg aspnetcore-debugger-mcp` should sta
 }
 ```
 
-### Claude Desktop (`claude_desktop_config.json`)
+**Claude Desktop** — same JSON shape goes in `claude_desktop_config.json`'s `mcpServers` block.
 
-Same shape — drop the snippet above into the `mcpServers` block.
+### Step 4 — Just chat with Claude
+
+Open Claude Code (or Claude Desktop) in your .NET project. Run `/mcp` to confirm `aspnetcore-debugger` shows as connected. From here, **don't invoke the tools yourself** — just describe what you want:
+
+> *"Debug my API and figure out why `GET /users/42` returns null."*
+
+Claude picks the right tools (`debug_launch`, `breakpoint_set`, `variables_get`, etc.) and reports back what it actually saw at runtime.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` so that creating a GitHub Release from a tag triggers a build → test → pack → publish pipeline. The tag is the version (leading `v` stripped), the nupkg is attached to the release, and `dotnet nuget push` to NuGet.org runs **only if** a `NUGET_API_KEY` secret is configured (otherwise it logs a clear warning and skips — safe to merge without the secret).

## How it works

- Triggers on `release: published` (or manual `workflow_dispatch` for dry runs)
- Setup .NET 10 → restore → build (Release) → test
- `dotnet pack` with the resolved version (e.g. tag `v0.1.0-preview` → version `0.1.0-preview`)
- Upload nupkg to the GitHub Release as a downloadable asset
- Push to NuGet.org if the secret is set

## What you need to do after merge (once)

1. Create a NuGet.org account if you don't have one.
2. Generate an API key at https://www.nuget.org/account/apikeys (scoped to the `AspNetCoreDebuggerMcp` package).
3. Add it as a repo secret named `NUGET_API_KEY` at:
   https://github.com/magna-nz/aspnetcore-debugger-mcp/settings/secrets/actions

Once that's in place, every published GitHub Release auto-publishes to NuGet.org.

## Release flow after this PR + the secret are set

```bash
git tag v0.1.0-preview
git push --tags
# Then in the GitHub UI: Releases → Draft a new release → pick the tag → Publish.
# The action runs and pushes the nupkg.
```

End users then install with:

```bash
dotnet tool install -g AspNetCoreDebuggerMcp --prerelease
```

## Test plan

- [ ] CI workflow still passes (no changes to ci.yml)
- [ ] After merge, try `gh workflow run release.yml -f version=0.1.0-dryrun` — should build/test/pack without pushing (push step's gate requires explicit opt-in for workflow_dispatch)
- [ ] Tag + publish a real release once the NUGET_API_KEY secret is set

Linear: MAG-40

🤖 Generated with [Claude Code](https://claude.com/claude-code)