### PR TITLE
README: add status badges (MAG-41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # aspnetcore-debugger-mcp
 
+[![CI](https://github.com/magna-nz/aspnetcore-debugger-mcp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/magna-nz/aspnetcore-debugger-mcp/actions/workflows/ci.yml)
+[![.NET](https://img.shields.io/badge/.NET-10-512BD4)](https://dotnet.microsoft.com/)
+[![MCP](https://img.shields.io/badge/MCP-compatible-005FBA)](https://modelcontextprotocol.io/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 **An MIT-licensed [Model Context Protocol](https://modelcontextprotocol.io/) server that lets an
 AI agent (Claude, etc.) debug your .NET / ASP.NET Core app — conversationally.**
 


### PR DESCRIPTION
## Summary

Adds the standard row of badges right under the title so the project at-a-glance shows CI health, .NET target, MCP compatibility, and license:

- **CI** — live from `.github/workflows/ci.yml` on `main` (turns green/red automatically)
- **.NET 10** — static target version
- **MCP compatible** — static, links to modelcontextprotocol.io
- **License: MIT** — static, links to LICENSE

## Why no NuGet badge yet?

Adding `![NuGet](https://img.shields.io/nuget/v/AspNetCoreDebuggerMcp.svg)` today would render "package not found" because we haven't published. Follow-up PR after the first `v0.1.0-preview` release.

## Test plan

- [ ] After merge, the CI badge on the README shows green (CI ran on the merge commit)

Linear: MAG-41

🤖 Generated with [Claude Code](https://claude.com/claude-code)