### PR TITLE
README: add NuGet version badge (MAG-42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # aspnetcore-debugger-mcp
 
 [![CI](https://github.com/magna-nz/aspnetcore-debugger-mcp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/magna-nz/aspnetcore-debugger-mcp/actions/workflows/ci.yml)
+[![NuGet](https://img.shields.io/nuget/vpre/AspNetCoreDebuggerMcp.svg?label=NuGet)](https://www.nuget.org/packages/AspNetCoreDebuggerMcp)
 [![.NET](https://img.shields.io/badge/.NET-10-512BD4)](https://dotnet.microsoft.com/)
 [![MCP](https://img.shields.io/badge/MCP-compatible-005FBA)](https://modelcontextprotocol.io/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)


### PR DESCRIPTION
## Summary

Adds the NuGet version badge to the README badge row, now that v0.1.0-preview is published.

Uses `nuget/vpre/AspNetCoreDebuggerMcp` (shows pre-release versions). The regular `nuget/v/` variant would render "no stable version" until we ship a non-preview release.

While NuGet finishes validating the freshly-pushed v0.1.0-preview, the badge will briefly render "package not found" — that resolves automatically as soon as the package is indexed.

Linear: MAG-42

🤖 Generated with [Claude Code](https://claude.com/claude-code)