### PR TITLE
Lean README + /docs folder (MAG-43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # aspnetcore-debugger-mcp
 
 [![CI](https://github.com/magna-nz/aspnetcore-debugger-mcp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/magna-nz/aspnetcore-debugger-mcp/actions/workflows/ci.yml)
+[![NuGet](https://img.shields.io/nuget/vpre/AspNetCoreDebuggerMcp.svg?label=NuGet)](https://www.nuget.org/packages/AspNetCoreDebuggerMcp)
 [![.NET](https://img.shields.io/badge/.NET-10-512BD4)](https://dotnet.microsoft.com/)
 [![MCP](https://img.shields.io/badge/MCP-compatible-005FBA)](https://modelcontextprotocol.io/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -16,13 +17,10 @@ actually saw.
 autopsy, hang analysis, and **server-side request tracing** that captures the full call chain
 with variables — without you setting any breakpoint manually.
 
----
-
 ## A taste — real output
 
-You tell Claude: *"Trace what `GET /order/42` does."*
-
-The agent traces 5 methods, hits the endpoint, and gets back:
+You tell Claude *"trace what `GET /order/42` does"* and the agent traces 5 methods, hits the
+endpoint, and returns:
 
 ```
 [+  679ms] → OrderController.GetOrder()       id=42, data=null
@@ -34,11 +32,9 @@ The agent traces 5 methods, hits the endpoint, and gets back:
 
 — Controller → Service → Repository → SqlClient (4 levels), with `Enrich` correctly shown as a
 sibling of the Repository call at depth 2. Each line is one captured method entry with its
-actual locals. The request returned 200; the trace shows the path it took.
+actual locals. No breakpoints set manually.
 
-No breakpoints were set manually. The agent picked the methods and called `trace_start`.
-
----
+[See 6 more worked examples →](docs/examples.md)
 
 ## How it works
 
@@ -55,330 +51,46 @@ netcoredbg                     ← Samsung's MIT-licensed .NET debugger, child p
 target .NET process
 ```
 
-The server is a protocol bridge: MCP server on one side, DAP client on the other. It drives
-[`netcoredbg`](https://github.com/Samsung/netcoredbg) and adds higher-level, agent-friendly
-composites on top — `exception_autopsy`, `stack_explore`, `hang_analyze`, and the trace tools.
-
----
+A protocol bridge with agent-friendly composites on top — `exception_autopsy`, `stack_explore`,
+`hang_analyze`, and the trace tools — that bundle multiple DAP requests into a single tool call.
 
 ## Use it in 4 steps
 
-Once per machine: install prerequisites and the tool. Once per project: register it. Then just chat.
+1. **Install prerequisites** — .NET 10 SDK + `netcoredbg` ([prebuilt for Linux/Win/Intel macOS](https://github.com/Samsung/netcoredbg/releases) · [build for macOS arm64](docs/macos-arm64.md))
+2. **Install the tool** — `dotnet tool install -g AspNetCoreDebuggerMcp --prerelease`
+3. **Register with Claude:**
+   ```bash
+   claude mcp add aspnetcore-debugger \
+     -e NETCOREDBG_PATH=/path/to/netcoredbg \
+     -- aspnetcore-debugger-mcp
+   ```
+   (Or edit `.mcp.json` / `claude_desktop_config.json` directly.)
+4. **Just chat with Claude.** `/mcp` confirms it's connected. From there, describe what you want — *"why does this endpoint return null"* — and the agent picks the right tools.
 
-### Step 1 — Prerequisites *(once per machine)*
+[Full install + troubleshooting →](docs/install.md)
 
-- **.NET 10 SDK** — [dotnet.microsoft.com/download](https://dotnet.microsoft.com/download)
-- **netcoredbg** — Samsung's MIT-licensed .NET debugger that this server drives:
-
-  | Platform | Get it from |
-  |---|---|
-  | Linux x64 / arm64 | [Samsung release](https://github.com/Samsung/netcoredbg/releases) |
-  | Windows x64 | [Samsung release](https://github.com/Samsung/netcoredbg/releases) |
-  | macOS Intel (x64) | [Samsung release](https://github.com/Samsung/netcoredbg/releases) |
-  | **macOS Apple Silicon (arm64)** | **No prebuilt — build with `scripts/build-netcoredbg-macos-arm64.sh`** |
-- **Claude Code** or **Claude Desktop** installed.
-
-### Step 2 — Install the MCP server *(once per machine)*
-
-```bash
-dotnet tool install -g AspNetCoreDebuggerMcp --prerelease
-```
-
-That puts the `aspnetcore-debugger-mcp` binary on your `PATH`. Verify:
-
-```bash
-NETCOREDBG_PATH=/path/to/netcoredbg aspnetcore-debugger-mcp
-# starts and idles on stdin; Ctrl-C to exit
-```
-
-### Step 3 — Register it with your MCP client *(once per project, or globally)*
-
-**Claude Code** — either run:
-
-```bash
-claude mcp add aspnetcore-debugger \
-  -e NETCOREDBG_PATH=/path/to/netcoredbg \
-  -- aspnetcore-debugger-mcp
-```
-
-or edit `.mcp.json` (project) / `~/.claude.json` (global) directly:
-
-```json
-{
-  "mcpServers": {
-    "aspnetcore-debugger": {
-      "command": "aspnetcore-debugger-mcp",
-      "env": { "NETCOREDBG_PATH": "/absolute/path/to/netcoredbg" }
-    }
-  }
-}
-```
-
-**Claude Desktop** — same JSON shape goes in `claude_desktop_config.json`'s `mcpServers` block.
-
-### Step 4 — Just chat with Claude
-
-Open Claude Code (or Claude Desktop) in your .NET project. Run `/mcp` to confirm `aspnetcore-debugger` shows as connected. From here, **don't invoke the tools yourself** — just describe what you want:
-
-> *"Debug my API and figure out why `GET /users/42` returns null."*
-
-Claude picks the right tools (`debug_launch`, `breakpoint_set`, `variables_get`, etc.) and reports back what it actually saw at runtime.
-
----
-
-## What you can do with it — worked examples
-
-These are the patterns this tool exists to make easy. Each example shows what you'd say to your
-AI assistant and what the agent does in response. The tool outputs shown are real — straight
-from the project's end-to-end test runs.
-
-### 1. "Why does this endpoint return wrong data?" — break and inspect
-
-> **You:** Why does `GET /hello/world` return `null` when I expect a greeting?
-
-The agent:
-
-1. `debug_launch program=bin/Debug/net10.0/WebApiTest.dll stopAtEntry=true`
-2. `breakpoint_wait` → entry stop, ready to configure
-3. `breakpoint_set sourcePath=Program.cs line=6` (inside the handler)
-4. `debug_continue` + wait for Kestrel to come up
-5. **You hit the endpoint** (or it tells curl to): `curl http://localhost:5099/hello/world`
-6. `breakpoint_wait` returns:
-
-```
-stop: { reason: "breakpoint", threadId: 12345 }
-topFrame: Program.<>c.<<Main>$>b__0_0()  [Program.cs:6]
-snippet:
-    4: app.MapGet("/hello/{name}", (string name) =>
-    5: {
-→   6:     var greeting = $"Hello, {name}!";
-    7:     var length = greeting.Length;
-    8:     return Results.Ok(new { greeting, length });
-```
-
-7. `variables_get` → sees `name="world"`, `greeting=null` (not yet assigned)
-8. `evaluate "name.ToUpper()"` → `"WORLD"` — runs against the live frame
-9. Agent answers with the real values, not guesses.
-
-### 2. "Test a fix without changing code" — mutate state mid-run
-
-> **You:** What if `userId` were `"u-001"` instead of empty?
-
-```
-[variables_set expression="userId" value="\"u-001\""]
-[debug_continue]
-[breakpoint_wait]   → function returned with a real User. Confirmed: bug is in the caller.
-```
-
-`variables_set` uses DAP `setExpression` so it works on any lvalue, including object members
-(`user.Name`, `dict[key]`, etc.).
-
-### 3. "Why did this throw?" — one-call exception autopsy
-
-> **You:** Catch any unhandled exception, then explain it.
-
-```
-[breakpoint_set_exception filters=["user-unhandled"]]
-[debug_continue]
-[breakpoint_wait]   → stopped, reason=exception
-[exception_autopsy]
-```
-
-Returns in one call:
-
-```
-exceptionId: "CLR/System.NullReferenceException"
-description: "Object reference not set to an instance of an object."
-layers: [
-  { typeName: "System.NullReferenceException", message: "..." }
-]
-stackFrames: [Program.<<Main>$>b__0_0, ...]
-topFrameLocals: { name: null, ... }
-topFrameSnippet:
-    6: var greeting = $"Hello, {name}!";
-    7: string? name = null;
-→   8: Console.WriteLine(name!.Length);
-```
-
-The agent gets type + inner-chain + frames + locals at the throw site + source snippet, all from
-a single tool call. No grepping logs for a bare stack trace with no context.
-
-### 4. "Trace the whole call chain through a request" — no manual breakpoints
-
-> **You:** Show me every method the request hits, with its arguments.
-
-```
-[trace_start methods=[
-   "OrderController.GetOrder",
-   "OrderService.LookupOrder",
-   "OrderRepository.FetchById",
-   "EnrichmentService.Enrich",
-   "SqlClient.ExecuteQuery"]]
-[debug_continue]              # Kestrel comes up
-(curl /order/42)
-[trace_get]
-```
-
-Output:
-
-```
-[+  679ms] → OrderController.GetOrder()       id=42, data=null
-[+  711ms] --→ OrderService.LookupOrder()     id=42, raw=null, enriched=null
-[+  735ms] ----→ OrderRepository.FetchById()  id=42
-[+  759ms] ------→ SqlClient.ExecuteQuery()   sql="SELECT * FROM orders WHERE id = 42"
-[+  783ms] ----→ EnrichmentService.Enrich()   raw="rows(sql=SELECT * FROM orders WHERE id …"
-```
-
-How it works under the hood: each named method gets a *server-side* trace breakpoint that
-captures the call (top frame + locals + stack) and **auto-continues immediately** — your code
-runs at near-normal speed, never visibly pausing. Indentation reflects the depth of *traced
-ancestors* in each frame's stack, so middleware and Kestrel internals don't inflate the depth.
-Sibling calls (FetchById and Enrich, both called by LookupOrder) sit at the same level.
-
-`trace_start` also captures unhandled exceptions during the trace (`includeExceptions=true` by
-default), rendered with `⚠` and a small stack.
-
-> Note: while a trace is active, the session can't also have user breakpoints. Call `trace_stop`
-> first if you want to switch modes.
-
-### 5. "Walk through a layered request when stopped" — `stack_explore`
-
-When you're paused inside a deeply layered request, this returns the entire call chain plus the
-locals at every frame in one call, with a rendered ASCII tree:
-
-```
-Microsoft.AspNetCore.Server.Kestrel...HttpProtocol.ProcessRequests()
-     │
-     ▼
-Microsoft.AspNetCore.HostFiltering.HostFilteringMiddleware.Invoke()
-     │
-     ▼
-[Native Frames]
-     │
-     ▼
-Program.<>c.<<Main>$>b__0_0()   [Program.cs:6]  ◄ paused here
-  name = "world", greeting = null, length = 0
-```
-
-Same shape as `stacktrace_get` + `variables_get` per frame, but consolidated into one tool call
-and with a human-readable tree string ready to drop into a reply. Async state-machine frames
-are flattened back to their original method names (e.g. `UserService.<GetAsync>d__3.MoveNext`
-→ `UserService.GetAsync`).
-
-### 6. "Why is the app hung?" — `hang_analyze`
-
-```
-[hang_analyze]
-```
-
-Auto-pauses if running, walks every thread, classifies each by what blocking primitive it's on
-(Monitor / WaitHandle / Semaphore / Task / Thread.Join / Sleep / async await), returns a summary:
-
-```
-blockedCount: 3
-notes: "Cycle detection requires lock-ownership data which DAP does not expose..."
-threads: [
-  { threadId: 1, name: "Main Thread", blockingKind: "blockedOnTask", topFrames: [...] },
-  { threadId: 8, name: ".NET ThreadPool Worker", blockingKind: "blockedOnMonitor", topFrames: [...] },
-  ...
-]
-```
-
-### 7. "Show me what's in the response logs" — `process_read_output`
-
-```
-[process_read_output]
-→ Drains stdout/stderr accumulated since the last call. For an ASP.NET Core app with default
-  request logging, that includes the `Request starting`/`Request finished … 200` lines.
-```
-
-Useful when you just want the server-side view of a request without setting breakpoints.
-
----
-
-## All 26 tools
+## Tools at a glance
 
 | Category | Tools |
 |---|---|
-| **Session** | `debug_launch`, `debug_attach`, `debug_disconnect`, `debug_state` |
-| **Breakpoints** | `breakpoint_set` (line + conditional + hit-count + logpoint), `breakpoint_set_function`, `breakpoint_set_exception`, `breakpoint_set_data`, `breakpoint_remove`, `breakpoint_list` |
-| **Execution** | `debug_continue`, `debug_pause`, `debug_step` (in/over/out), `breakpoint_wait` (blocks until next stop, includes top frame + source snippet) |
-| **Inspection** | `threads_list`, `stacktrace_get`, `variables_get` (recursive expansion + truncation), `evaluate`, `variables_set` (via DAP `setExpression`, handles any lvalue), `stack_explore` (stack + locals at every frame + ASCII tree, one call) |
-| **Diagnostics** | `exception_autopsy` (chain + frames + locals + snippet), `hang_analyze` (per-thread blocking classification), `trace_start` / `trace_get` / `trace_stop` (server-side call-chain tracing with auto-continue), `process_read_output` (drain buffered stdout/stderr) |
+| **Session** | launch / attach / disconnect / state |
+| **Breakpoints** | line (conditional/hit-count/logpoint), function, exception, data, remove, list |
+| **Execution** | continue / pause / step / blocking wait-for-stop |
+| **Inspection** | threads / stack / variables / evaluate / set-variable / **`stack_explore` composite** |
+| **Diagnostics** | **`exception_autopsy`** · **`hang_analyze`** · **`trace_start/get/stop`** · stdout drain |
 
----
+26 tools total. [Full reference with parameters →](docs/tools.md)
 
-## When NOT to use this tool
+## Docs
 
-Be honest about scope:
-
-| Want | Reach for |
-|---|---|
-| "Why does this return wrong data" | **this tool** — pause, read state, find out |
-| "Every method called during a request, with arguments" | **`trace_start`** in this tool |
-| "Every method ever called, no instrumentation" | A sampling profiler (`dotnet-trace`, OpenTelemetry) |
-| "Just hit my endpoint and see the response" | `curl` |
-| "What's slow?" | A profiler — debuggers don't measure perf |
-| "Production observability" | Logs / metrics / APM |
-| "Read the code" | Your IDE / GitHub |
-
----
-
-## macOS Apple Silicon — building netcoredbg
-
-Samsung doesn't publish an arm64 macOS prebuilt. Use the included script:
-
-```bash
-./scripts/build-netcoredbg-macos-arm64.sh
-```
-
-Requires Xcode Command Line Tools, CMake (`brew install cmake`), .NET 10 SDK. Clones
-`Samsung/netcoredbg`, configures, builds, installs, and prints the `NETCOREDBG_PATH` to export.
-
-> Samsung notes the arm64 macOS build is "community supported and may not work as expected." In
-> our testing on Apple Silicon, every debugger feature used by this project works correctly
-> except `dataBreakpointInfo` (returns `E_NOTIMPL`) — see Known limits.
-
----
-
-## Known limits
-
-- **`breakpoint_set_data` depends on the adapter.** netcoredbg currently returns `E_NOTIMPL` for
-  `dataBreakpointInfo`. The tool surfaces this as a clean error; another adapter (or a future
-  netcoredbg) would just work.
-- **`process_write_input` is not implemented.** DAP launch mode owns the debuggee's stdin;
-  plumbing input requires a different launch architecture (we launch the process, netcoredbg
-  attaches).
-- **Tracing has overhead.** Each trace BP hit ≈ a handful of DAP round-trips. Fine for tracing a
-  few methods through a single request; **not** suited to high-throughput loads or tracing every
-  method in a namespace — use a real profiler for that.
-- **Trace mode owns all breakpoints.** While a trace is active, user breakpoints can't be added
-  — call `trace_stop` first.
-- **Async continuation chains.** Async state-machine frame *names* are flattened back to their
-  original methods, but we don't walk the heap to reconstruct logical "who awaited this" when
-  the awaiter isn't on the current thread. That would need ICorDebug-level access beyond what
-  DAP exposes.
-
----
-
-## Build from source
-
-```bash
-git clone https://github.com/magna-nz/aspnetcore-debugger-mcp.git
-cd aspnetcore-debugger-mcp
-dotnet build
-dotnet test
-NETCOREDBG_PATH=/path/to/netcoredbg dotnet run --project src/AspNetCoreDebuggerMcp
-```
-
-79+ unit tests cover the DAP client, breakpoint registry, stop-waiter, state machine, async
-frame flattening, stack-tree rendering, thread blocking classifier, source-snippet reader, and
-trace renderer. End-to-end smokes exercise the full pipeline against a real ASP.NET Core Web
-API on netcoredbg.
-
----
+- **[Install & configure](docs/install.md)** — 4 steps, both Claude Code & Desktop, troubleshooting
+- **[Worked examples](docs/examples.md)** — 7 real use cases with actual tool output
+- **[Full tool reference](docs/tools.md)** — every parameter on every tool
+- **[Known limits](docs/limits.md)** — when *not* to use this tool, adapter & tracing limits
+- **[macOS Apple Silicon — building netcoredbg](docs/macos-arm64.md)**
+- **[Contributing](docs/contributing.md)** — repo layout, tests, dev loop
 
 ## License
 
-MIT — see [LICENSE](LICENSE). Depends on `netcoredbg` (also MIT) and the `ModelContextProtocol`
-SDK (MIT).
+MIT — see [LICENSE](LICENSE). Built on [netcoredbg](https://github.com/Samsung/netcoredbg) (MIT)
+and the [ModelContextProtocol SDK](https://github.com/modelcontextprotocol/csharp-sdk) (MIT).

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,6 @@
+title: aspnetcore-debugger-mcp
+description: An MIT-licensed Model Context Protocol server that lets AI agents debug .NET / ASP.NET Core apps conversationally.
+theme: jekyll-theme-cayman
+show_downloads: false
+github:
+  is_project_page: true

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,78 @@
+# Contributing / building from source
+
+## Build & test
+
+```bash
+git clone https://github.com/magna-nz/aspnetcore-debugger-mcp.git
+cd aspnetcore-debugger-mcp
+dotnet build
+dotnet test
+NETCOREDBG_PATH=/path/to/netcoredbg dotnet run --project src/AspNetCoreDebuggerMcp
+```
+
+Requires .NET 10 SDK + `netcoredbg` on your machine (see [Install](install.md) and
+[macOS arm64 build](macos-arm64.md)).
+
+## Project layout
+
+```
+src/AspNetCoreDebuggerMcp/
+├── Program.cs              # Entry point, DI, MCP server config
+├── Dap/                    # Hand-rolled DAP client (Content-Length framing,
+│                           #   request/response correlation, event dispatch)
+├── Debugging/              # DebugSession, DebugSessionManager, NetcoredbgProcess,
+│                           #   SessionStateMachine, StopWaiter
+├── Breakpoints/            # BreakpointRegistry, record types
+├── Inspection/             # InspectionService (threads/stack/scopes/variables/
+│                           #   evaluate/setExpression/exceptionInfo), AsyncStackFlattener,
+│                           #   StackTreeRenderer
+├── Diagnostics/            # ThreadAnalyzer, TraceCollector, TraceRenderer, OutputLine
+└── Tools/                  # 26 MCP tools across 5 categories
+
+tests/AspNetCoreDebuggerMcp.Tests/    # 80+ xUnit unit tests
+.github/workflows/
+├── ci.yml                  # Linux + macOS build/test/pack on every push and PR
+└── release.yml             # On GitHub Release published: pack + attach + push to NuGet
+scripts/
+└── build-netcoredbg-macos-arm64.sh    # Builds netcoredbg natively for Apple Silicon
+```
+
+## Architecture in one sentence
+
+**Protocol bridge.** MCP server on one side (Claude talks to us), DAP client on the other (we
+talk to netcoredbg over a child-process stdio pipe). The interesting parts are the agent-friendly
+composites — `exception_autopsy`, `stack_explore`, `trace_start`, `hang_analyze` — that bundle
+multiple DAP requests into a single tool call returning structured + pre-rendered output the
+agent can drop into a reply.
+
+## Running the demos
+
+The repository's end-to-end demos live in the developer's local job dir during development; the
+unit tests are the canonical "this works" signal. To exercise the full pipeline manually:
+
+```bash
+# 1. Build a tiny ASP.NET Core test app
+dotnet new web -o /tmp/Demo
+# (write a small Program.cs handler)
+
+# 2. Run the MCP server pointing at netcoredbg
+NETCOREDBG_PATH=~/projects/netcoredbg-src/bin/netcoredbg \
+  dotnet run --project src/AspNetCoreDebuggerMcp
+
+# 3. From an MCP client (or a script), call debug_launch / breakpoint_set / etc.
+```
+
+## Pull requests
+
+- Branch naming: `feature/MAG-<number>-<short-name>`
+- One PR per logical change (the project uses Linear ticket numbers in branches and commit messages)
+- Tests for new behavior — the project keeps to TDD where the surface allows (pure helpers like
+  `AsyncStackFlattener`, `StackTreeRenderer`, `ThreadAnalyzer`, `TraceRenderer`, `StopWaiter`,
+  `BreakpointRegistry` all have dedicated test classes)
+- Build clean (0 warnings, 0 errors)
+
+## Release process
+
+See the [Release workflow](https://github.com/magna-nz/aspnetcore-debugger-mcp/blob/main/.github/workflows/release.yml).
+Drafting + publishing a GitHub Release on a `vX.Y.Z` tag triggers the action; the nupkg is
+attached to the release and pushed to NuGet.org (if `NUGET_API_KEY` is set as a repo secret).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,199 @@
+# Worked examples
+
+Seven patterns this tool exists to make easy. Each example shows what you'd say to your AI
+assistant and what the agent does in response. The tool outputs shown are real — straight from
+the project's end-to-end test runs against a real ASP.NET Core Web API on netcoredbg.
+
+- [1. Why does this endpoint return wrong data? — break and inspect](#1-why-does-this-endpoint-return-wrong-data--break-and-inspect)
+- [2. Test a fix without changing code — mutate state mid-run](#2-test-a-fix-without-changing-code--mutate-state-mid-run)
+- [3. Why did this throw? — one-call exception autopsy](#3-why-did-this-throw--one-call-exception-autopsy)
+- [4. Trace the whole call chain through a request — no manual breakpoints](#4-trace-the-whole-call-chain-through-a-request--no-manual-breakpoints)
+- [5. Walk through a layered request when stopped — `stack_explore`](#5-walk-through-a-layered-request-when-stopped--stack_explore)
+- [6. Why is the app hung? — `hang_analyze`](#6-why-is-the-app-hung--hang_analyze)
+- [7. Show me what's in the response logs — `process_read_output`](#7-show-me-whats-in-the-response-logs--process_read_output)
+
+---
+
+## 1. Why does this endpoint return wrong data? — break and inspect
+
+> **You:** Why does `GET /hello/world` return `null` when I expect a greeting?
+
+The agent:
+
+1. `debug_launch program=bin/Debug/net10.0/WebApiTest.dll stopAtEntry=true`
+2. `breakpoint_wait` → entry stop, ready to configure
+3. `breakpoint_set sourcePath=Program.cs line=6` (inside the handler)
+4. `debug_continue` + waits for Kestrel to come up
+5. **You hit the endpoint** (or it tells `curl` to): `curl http://localhost:5099/hello/world`
+6. `breakpoint_wait` returns:
+
+```
+stop: { reason: "breakpoint", threadId: 12345 }
+topFrame: Program.<>c.<<Main>$>b__0_0()  [Program.cs:6]
+snippet:
+    4: app.MapGet("/hello/{name}", (string name) =>
+    5: {
+→   6:     var greeting = $"Hello, {name}!";
+    7:     var length = greeting.Length;
+    8:     return Results.Ok(new { greeting, length });
+```
+
+7. `variables_get` → sees `name="world"`, `greeting=null` (not yet assigned)
+8. `evaluate "name.ToUpper()"` → `"WORLD"` — runs against the live frame
+9. Agent answers with the real values, not guesses.
+
+---
+
+## 2. Test a fix without changing code — mutate state mid-run
+
+> **You:** What if `userId` were `"u-001"` instead of empty?
+
+```
+[variables_set expression="userId" value="\"u-001\""]
+[debug_continue]
+[breakpoint_wait]   → function returned with a real User. Confirmed: bug is in the caller.
+```
+
+`variables_set` uses DAP `setExpression` so it works on any lvalue, including object members
+(`user.Name`, `dict[key]`, etc.) — not just bare variable names.
+
+---
+
+## 3. Why did this throw? — one-call exception autopsy
+
+> **You:** Catch any unhandled exception, then explain it.
+
+```
+[breakpoint_set_exception filters=["user-unhandled"]]
+[debug_continue]
+[breakpoint_wait]   → stopped, reason=exception
+[exception_autopsy]
+```
+
+Returns in one call:
+
+```
+exceptionId: "CLR/System.NullReferenceException"
+description: "Object reference not set to an instance of an object."
+layers: [
+  { typeName: "System.NullReferenceException", message: "..." }
+]
+stackFrames: [Program.<<Main>$>b__0_0, ...]
+topFrameLocals: { name: null, ... }
+topFrameSnippet:
+    6: var greeting = $"Hello, {name}!";
+    7: string? name = null;
+→   8: Console.WriteLine(name!.Length);
+```
+
+The agent gets type + inner-chain + frames + locals at the throw site + source snippet, **all
+from a single tool call**. No grepping logs for a bare stack trace with no context.
+
+---
+
+## 4. Trace the whole call chain through a request — no manual breakpoints
+
+> **You:** Show me every method the request hits, with its arguments.
+
+```
+[trace_start methods=[
+   "OrderController.GetOrder",
+   "OrderService.LookupOrder",
+   "OrderRepository.FetchById",
+   "EnrichmentService.Enrich",
+   "SqlClient.ExecuteQuery"]]
+[debug_continue]              # Kestrel comes up
+(curl /order/42)
+[trace_get]
+```
+
+Output:
+
+```
+[+  679ms] → OrderController.GetOrder()       id=42, data=null
+[+  711ms] --→ OrderService.LookupOrder()     id=42, raw=null, enriched=null
+[+  735ms] ----→ OrderRepository.FetchById()  id=42
+[+  759ms] ------→ SqlClient.ExecuteQuery()   sql="SELECT * FROM orders WHERE id = 42"
+[+  783ms] ----→ EnrichmentService.Enrich()   raw="rows(sql=SELECT * FROM orders WHERE id …"
+```
+
+How it works: each named method gets a **server-side** trace breakpoint that captures the call
+(top frame + locals + stack) and **auto-continues immediately** — your code runs at near-normal
+speed, never visibly pausing. Indentation reflects the depth of *traced ancestors* in each
+frame's stack, so middleware and Kestrel internals don't inflate the depth. Sibling calls
+(`FetchById` and `Enrich`, both called by `LookupOrder`) sit at the same level.
+
+`trace_start` also captures unhandled exceptions during the trace (`includeExceptions=true` by
+default), rendered with `⚠` and a small stack.
+
+> Note: while a trace is active, the session can't also have user breakpoints. Call `trace_stop`
+> first if you want to switch modes.
+
+---
+
+## 5. Walk through a layered request when stopped — `stack_explore`
+
+When you're paused inside a deeply layered request, this returns the entire call chain plus the
+locals at every frame in one call, with a rendered ASCII tree:
+
+```
+Microsoft.AspNetCore.Server.Kestrel...HttpProtocol.ProcessRequests()
+     │
+     ▼
+Microsoft.AspNetCore.HostFiltering.HostFilteringMiddleware.Invoke()
+     │
+     ▼
+[Native Frames]
+     │
+     ▼
+Program.<>c.<<Main>$>b__0_0()   [Program.cs:6]  ◄ paused here
+  name = "world", greeting = null, length = 0
+```
+
+Same data as `stacktrace_get` + `variables_get` per frame, but consolidated into one call and
+with a human-readable tree string ready to drop into a reply. Async state-machine frames are
+flattened back to their original method names (e.g. `UserService.<GetAsync>d__3.MoveNext` →
+`UserService.GetAsync`).
+
+---
+
+## 6. Why is the app hung? — `hang_analyze`
+
+```
+[hang_analyze]
+```
+
+Auto-pauses if running, walks every thread, classifies each by what blocking primitive it's
+stuck on (`Monitor` / `WaitHandle` / `Semaphore` / `Task` / `Thread.Join` / `Sleep` /
+`AwaitingAsync`), returns a summary:
+
+```
+blockedCount: 3
+notes: "Cycle detection requires lock-ownership data which DAP does not expose..."
+threads: [
+  { threadId: 1, name: "Main Thread",             blockingKind: "blockedOnTask",    topFrames: [...] },
+  { threadId: 8, name: ".NET ThreadPool Worker",  blockingKind: "blockedOnMonitor", topFrames: [...] },
+  ...
+]
+```
+
+---
+
+## 7. Show me what's in the response logs — `process_read_output`
+
+```
+[process_read_output]
+```
+
+Drains stdout/stderr accumulated since the last call. For an ASP.NET Core app with default
+request logging, that includes the `Request starting` / `Request finished … 200` lines.
+
+Useful when you just want the server-side view of a request without setting breakpoints.
+
+---
+
+## See also
+
+- [Full tool reference](tools.md) — every parameter on every tool
+- [Known limits](limits.md) — what this tool *isn't* for
+- [Install](install.md) — to set up the prerequisites if you haven't already

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,41 @@
+# aspnetcore-debugger-mcp — documentation
+
+An MIT-licensed [Model Context Protocol](https://modelcontextprotocol.io/) server that lets an AI
+agent (Claude, etc.) debug your .NET / ASP.NET Core app — conversationally.
+
+## Pages
+
+- **[Install & configure](install.md)** — the 4-step setup (prerequisites → tool install → MCP register → chat).
+- **[Worked examples](examples.md)** — 7 real use cases with the actual tool output the agent sees.
+- **[Full tool reference](tools.md)** — every one of the 26 tools, grouped by category.
+- **[macOS Apple Silicon — building netcoredbg](macos-arm64.md)** — what to do when no Samsung prebuilt exists.
+- **[Known limits](limits.md)** — what this tool *isn't* for, and where the adapter falls short.
+- **[Contributing / building from source](contributing.md)** — repo layout, tests, dev loop.
+
+## What it does, in one paragraph
+
+Instead of *"I think the bug is around line 42, try this"*, the agent runs your code, pauses it,
+reads the actual runtime values, mutates state to test a fix, and answers grounded in what it
+actually saw. 26 tools across launching, breakpoints, stepping, inspection, expression evaluation,
+exception autopsy, hang analysis, and **server-side request tracing** that captures the full call
+chain with variables — without you setting any breakpoint manually.
+
+## Quick teaser — real output
+
+You tell Claude *"trace what `GET /order/42` does"* and you get back:
+
+```
+[+  679ms] → OrderController.GetOrder()       id=42, data=null
+[+  711ms] --→ OrderService.LookupOrder()     id=42, raw=null, enriched=null
+[+  735ms] ----→ OrderRepository.FetchById()  id=42
+[+  759ms] ------→ SqlClient.ExecuteQuery()   sql="SELECT * FROM orders WHERE id = 42"
+[+  783ms] ----→ EnrichmentService.Enrich()   raw="rows(sql=SELECT * FROM orders WHERE id …"
+```
+
+4 layers, with `Enrich` correctly shown as a sibling of the Repository call at depth 2. No
+manual breakpoints. See [the full examples](examples.md) for the other patterns.
+
+## License
+
+MIT. Built on [netcoredbg](https://github.com/Samsung/netcoredbg) (MIT) and the
+[ModelContextProtocol SDK](https://github.com/modelcontextprotocol/csharp-sdk) (MIT).

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,113 @@
+# Install & configure
+
+Once per machine: install prerequisites and the tool. Once per project: register it. Then just chat.
+
+## Step 1 — Prerequisites *(once per machine)*
+
+- **.NET 10 SDK** — [dotnet.microsoft.com/download](https://dotnet.microsoft.com/download)
+- **netcoredbg** — Samsung's MIT-licensed .NET debugger that this server drives:
+
+  | Platform | Get it from |
+  |---|---|
+  | Linux x64 / arm64 | [Samsung release](https://github.com/Samsung/netcoredbg/releases) — extract anywhere |
+  | Windows x64 | [Samsung release](https://github.com/Samsung/netcoredbg/releases) — extract anywhere |
+  | macOS Intel (x64) | [Samsung release](https://github.com/Samsung/netcoredbg/releases) — extract anywhere |
+  | **macOS Apple Silicon (arm64)** | No prebuilt — see [Building netcoredbg on macOS arm64](macos-arm64.md) |
+
+  Tell the server where the binary lives via one of:
+  - Set `NETCOREDBG_PATH` to its absolute path *(recommended)*
+  - Put `netcoredbg` on your `PATH`
+  - Place it next to this tool's assembly
+- **Claude Code** or **Claude Desktop** installed.
+
+## Step 2 — Install the MCP server *(once per machine)*
+
+```bash
+dotnet tool install -g AspNetCoreDebuggerMcp --prerelease
+```
+
+`--prerelease` is needed while the version is `0.1.0-preview` (or any `-preview`/`-rc` suffix). Drop it once a stable `1.0.0` ships.
+
+That puts the `aspnetcore-debugger-mcp` binary on your `PATH`. Verify:
+
+```bash
+NETCOREDBG_PATH=/path/to/netcoredbg aspnetcore-debugger-mcp
+# starts and idles on stdin; Ctrl-C to exit
+```
+
+If it errors with *"netcoredbg not found"*, the env var or PATH isn't pointing at the binary — re-check Step 1.
+
+## Step 3 — Register with your MCP client *(once per project, or globally)*
+
+### Claude Code
+
+Either CLI:
+
+```bash
+claude mcp add aspnetcore-debugger \
+  -e NETCOREDBG_PATH=/path/to/netcoredbg \
+  -- aspnetcore-debugger-mcp
+```
+
+Or edit `.mcp.json` (project) / `~/.claude.json` (global):
+
+```json
+{
+  "mcpServers": {
+    "aspnetcore-debugger": {
+      "command": "aspnetcore-debugger-mcp",
+      "env": { "NETCOREDBG_PATH": "/absolute/path/to/netcoredbg" }
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Edit `claude_desktop_config.json` — same JSON shape goes in the `mcpServers` block:
+
+```json
+{
+  "mcpServers": {
+    "aspnetcore-debugger": {
+      "command": "aspnetcore-debugger-mcp",
+      "env": { "NETCOREDBG_PATH": "/absolute/path/to/netcoredbg" }
+    }
+  }
+}
+```
+
+Restart Claude Desktop after editing.
+
+## Step 4 — Just chat with Claude
+
+Open Claude Code or Claude Desktop in your .NET project. Run `/mcp` — `aspnetcore-debugger` should show as **connected**.
+
+From here, **don't invoke the tools yourself**. Just describe what you want:
+
+> *"Debug my API and figure out why `GET /users/42` returns null."*
+
+Claude picks the right tools (`debug_launch`, `breakpoint_set`, `variables_get`, etc.) and reports back what it actually saw at runtime. See the [worked examples](examples.md) for the patterns this enables.
+
+## Updating
+
+```bash
+dotnet tool update -g AspNetCoreDebuggerMcp --prerelease
+```
+
+## Uninstalling
+
+```bash
+dotnet tool uninstall -g AspNetCoreDebuggerMcp
+```
+
+Then remove the `aspnetcore-debugger` entry from your MCP client config.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `/mcp` shows the server as failed / disconnected | The `aspnetcore-debugger-mcp` binary isn't on PATH, or `NETCOREDBG_PATH` is wrong. Run the verify command from Step 2 in a regular shell. |
+| Tool calls error with *"netcoredbg not found"* | `NETCOREDBG_PATH` env var not propagating from MCP client config — make sure it's set in the `env` block of the server entry. |
+| First debug session hangs on launch | netcoredbg arm64 macOS build hasn't been built — see [macOS arm64](macos-arm64.md). |
+| Trace tool errors with "user breakpoints exist" | Trace mode requires no user BPs — call `breakpoint_remove` on each first, or `trace_stop` if a previous trace is still active. |

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -1,0 +1,54 @@
+# Known limits
+
+Honest scope notes. These aren't bugs — they're trade-offs we made, or things the underlying
+debugger adapter doesn't support.
+
+## When NOT to use this tool
+
+A debugger fundamentally needs to **pause** to see anything. If you don't want to pause, this is
+the wrong tool. Use the right tool for the job:
+
+| Want | Use |
+|---|---|
+| "Why does this return wrong data" | **this tool** — pause, read state, find out |
+| "Every method called during a request, with arguments" | **`trace_start`** in this tool |
+| "Every method ever called, no instrumentation, no manual list" | A sampling profiler (`dotnet-trace`, OpenTelemetry) |
+| "Just hit my endpoint and see the response" | `curl` |
+| "What's slow?" | A profiler — debuggers don't measure perf |
+| "Production observability" | Logs / metrics / APM |
+| "Read the code" | Your IDE / GitHub |
+
+## Adapter limits
+
+- **`breakpoint_set_data` depends on the adapter.** netcoredbg currently returns `E_NOTIMPL` for
+  `dataBreakpointInfo`. The tool surfaces this as a clean error; another adapter (or a future
+  netcoredbg) would just work — no code change needed on our side.
+- **`process_write_input` is not implemented.** DAP launch mode owns the debuggee's stdin;
+  piping input would require a different launch architecture (we launch the process, netcoredbg
+  attaches). Doable, just not done.
+
+## Tracing limits
+
+- **Tracing has overhead.** Each trace BP hit ≈ a handful of DAP round-trips. Fine for tracing a
+  few methods through a single request (a few hundred ms total overhead); **not** suited to
+  high-throughput loads or tracing every method in a namespace — use a real profiler for that.
+- **Trace mode owns all breakpoints.** While a trace is active, user breakpoints can't be added.
+  This sidesteps netcoredbg not populating `hitBreakpointIds` in stopped events, so we can't
+  otherwise tell a trace BP hit from a user BP hit. Call `trace_stop` first if you need to set
+  user breakpoints.
+
+## Async-stack limits
+
+- **State-machine frame names are flattened** (`UserService.<GetAsync>d__3.MoveNext` →
+  `UserService.GetAsync`) and BCL async infrastructure is hidden — good enough for normal use.
+- We **don't walk the heap to reconstruct logical "who awaited this"** when the awaiter isn't on
+  the current thread. That needs ICorDebug-level access beyond what DAP exposes. If this becomes
+  a pain point, it's a future enhancement.
+
+## What you can fix with config / your code
+
+| Symptom | Fix |
+|---|---|
+| `breakpoint_set_function` doesn't hit | Use the exact symbol name. For generic methods, include the type parameter (`Foo``1.Bar`). |
+| Trace shows depth 0 for everything | Increase `maxFramesPerEvent` so the captured stack reaches your traced ancestors. |
+| Variable values show as `null` when you expect data | The breakpoint may have hit *before* assignment — check the source snippet. |

--- a/docs/macos-arm64.md
+++ b/docs/macos-arm64.md
@@ -1,0 +1,54 @@
+# macOS Apple Silicon — building netcoredbg
+
+Samsung doesn't publish an arm64 macOS prebuilt of netcoredbg. The repo includes a script that
+builds it from source.
+
+## Prerequisites
+
+- Xcode Command Line Tools — `xcode-select --install`
+- CMake — `brew install cmake`
+- .NET 10 SDK — [dotnet.microsoft.com/download](https://dotnet.microsoft.com/download)
+- `git`
+
+## Run the script
+
+```bash
+./scripts/build-netcoredbg-macos-arm64.sh
+```
+
+What it does:
+
+1. Clones `Samsung/netcoredbg` (shallow) to `~/projects/netcoredbg-src` (override with a first arg)
+2. Configures via CMake with the modern-CMake policy override (`-DCMAKE_POLICY_VERSION_MINIMUM=3.5`)
+3. Builds with all cores (`make -j$(sysctl -n hw.ncpu)`)
+4. Installs into `<src>/bin/`
+5. Prints the `NETCOREDBG_PATH` to export
+
+When it finishes, you'll see:
+
+```
+Built: /Users/you/projects/netcoredbg-src/bin/netcoredbg
+
+Add this to your shell profile (and current shell):
+    export NETCOREDBG_PATH=/Users/you/projects/netcoredbg-src/bin/netcoredbg
+```
+
+## Is it stable?
+
+Samsung's docs say the arm64 macOS build is "community supported and may not work as expected."
+In our testing on Apple Silicon, every debugger feature used by this project works correctly,
+**except** `dataBreakpointInfo` (returns `E_NOTIMPL`) — see [Known limits](limits.md).
+
+The validated-on-arm64 functionality includes: launch, attach, line/function/exception
+breakpoints (with conditions, hit counts, logpoints), step in/over/out, threads, stack traces,
+scopes, variables, evaluate, setExpression, exceptionInfo, output events.
+
+## Why a script instead of a prebuilt binary in this repo?
+
+Distributing a prebuilt unsigned binary in a Git repo brings up signing / notarization /
+gatekeeper friction on Apple Silicon. The build script is small, deterministic, and uses your
+own toolchain — much cleaner than shipping bytes someone else has to trust.
+
+If we ever need a quicker install path, the right move is to build the netcoredbg arm64 binary
+in CI and attach it to GitHub Releases — then the MCP server's auto-discover code can fall back
+to a downloaded binary. Not done yet; happy to add it if it's annoying enough.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,71 @@
+# Full tools reference
+
+All 26 MCP tools, grouped by category. Tool names map directly to the `name` field in your MCP
+client; agents call them via normal tool-use mechanics — you don't invoke them by hand.
+
+## Session
+
+Lifecycle of one debug session (only one at a time per server instance).
+
+| Tool | Purpose |
+|---|---|
+| `debug_launch` | Launch a .NET program (`.dll` or apphost) under the debugger. Optional `stopAtEntry`. |
+| `debug_attach` | Attach to an already-running .NET process by PID. |
+| `debug_disconnect` | Terminate the debuggee and tear down the session. |
+| `debug_state` | Return the current session state, process id, and last stop info. |
+
+## Breakpoints
+
+The breakpoint registry is the authoritative intent — every mutation re-sends the full per-source
+or per-list set to the DAP adapter.
+
+| Tool | Purpose |
+|---|---|
+| `breakpoint_set` | Line breakpoint. Supports `condition`, `hitCondition`, and `logMessage` (logpoint / tracepoint). |
+| `breakpoint_set_function` | Break when a function is entered, by symbol name. |
+| `breakpoint_set_exception` | Set the active exception-breakpoint filters (`all`, `user-unhandled`). |
+| `breakpoint_set_data` | Watchpoint on a variable. **netcoredbg returns `E_NOTIMPL`** currently — see [limits](limits.md). |
+| `breakpoint_remove` | Remove a breakpoint by id (line, function, or data). |
+| `breakpoint_list` | Snapshot of every breakpoint currently set. |
+
+## Execution
+
+| Tool | Purpose |
+|---|---|
+| `debug_continue` | Resume the debuggee (defaults to the last-stopped thread). |
+| `debug_pause` | Pause a thread. |
+| `debug_step` | Single-step. `kind: "in"` / `"over"` / `"out"`. |
+| `breakpoint_wait` | **Blocking** wait for the next stop. Returns the stop info **plus auto-context**: top stack frame and a source snippet around the stop with an arrow marker. |
+
+## Inspection
+
+| Tool | Purpose |
+|---|---|
+| `threads_list` | List all threads in the debuggee. |
+| `stacktrace_get` | Call stack of a thread. Async state-machine frames are flattened back to original method names by default; pass `raw=true` for the unmodified DAP frames. |
+| `variables_get` | Scopes + variables for a frame. Recursively expands compound values up to `depth` levels, truncates at `maxChildren`. |
+| `evaluate` | Evaluate a C# expression in the context of a frame. |
+| `variables_set` | Set the value of a variable or any lvalue expression (uses DAP `setExpression` — accepts `user.Name`, `dict[key]`, etc., not just bare names). |
+| `stack_explore` | **Composite.** In one call: full stack + locals at every frame + a pre-rendered ASCII tree showing caller → callee with arrows. |
+
+## Diagnostics
+
+The agent-value-add tools — composites that bundle multiple DAP requests with structured + pretty-printed output.
+
+| Tool | Purpose |
+|---|---|
+| `exception_autopsy` | **Composite.** Exception type + inner-exception chain + top stack frames + top-frame locals + source snippet around the throw, all from one call. Use when `state.lastStop.reason == "exception"`. |
+| `hang_analyze` | **Composite.** Auto-pauses if running, lists every thread, classifies each by what blocking primitive it's on (`Monitor` / `WaitHandle` / `Semaphore` / `Task` / `Thread.Join` / `Sleep` / `AwaitingAsync` / `Running`). |
+| `trace_start` | Begin server-side request tracing. Named methods get internal trace breakpoints that capture the call (top frame + locals + stack) and auto-continue — the request flows at near-normal speed and your foreground debug state is untouched. Optional `includeExceptions=true` also captures unhandled exceptions. |
+| `trace_get` | Read the trace events captured since `trace_start`, plus a pre-rendered ASCII timeline with `→` for method entries and `⚠` for exceptions. |
+| `trace_stop` | Stop the active trace and remove its breakpoints. |
+| `process_read_output` | Drain the debuggee's stdout/stderr accumulated since the last call. With ASP.NET Core's default request logging this gives you `Request starting` / `Request finished … 200` lines per request. |
+
+## Tool design notes
+
+- **Return shape** — every tool returns JSON of the form `{"success": true, ...}` or `{"success": false, "error": "..."}`. Enums are serialised as camelCase strings (e.g. `"blockedOnMonitor"`, not `0`).
+- **`null` parameters** are omitted by the DAP client before serialisation — netcoredbg's parser rejects null string values in some places.
+- **Defaults** — tools that take optional thread / frame / depth / timeout parameters resolve sensible defaults (last-stopped thread, topmost frame, depth 1, 30 s wait timeout).
+- **Composites** (`exception_autopsy`, `stack_explore`, `hang_analyze`, `trace_*`) bundle multiple DAP requests and return **both** structured data and a pre-rendered text view ready to drop into a reply.
+
+See the [worked examples](examples.md) for what these look like in actual use.


### PR DESCRIPTION
## Summary

Slims `README.md` from ~350 lines to **96 lines** and moves the detailed material into a new `/docs` folder ready for GitHub Pages.

## What's in the new README (≈96 lines)

- Badges
- 1-paragraph pitch
- One real-output teaser (the trace tree)
- How-it-works diagram (kept — it's load-bearing context)
- "Use it in 4 steps" — condensed to bullets with links into docs
- Tools-at-a-glance table (one line per category, links to full reference)
- Links to all docs pages
- License

## /docs structure

| File | Purpose | Lines |
|---|---|---|
| `_config.yml` | GitHub Pages config — Jekyll Cayman theme, no Node build | 7 |
| `index.md` | Landing page with nav | 41 |
| `install.md` | Full 4-step setup + Claude Code/Desktop + update/uninstall + troubleshooting | 113 |
| `examples.md` | The 7 worked examples extracted from the old README | 199 |
| `tools.md` | Full 26-tool reference, grouped by category | 71 |
| `macos-arm64.md` | netcoredbg build details + script + caveats | 54 |
| `limits.md` | "When NOT to use this" matrix + adapter/tracing/async limits | 54 |
| `contributing.md` | Repo layout, tests, dev loop, release process | 78 |

Total docs ≈ 610 lines, but organised — readers go straight to the page they need.

## Internal links

All cross-doc links are relative (`(install.md)`, `(tools.md)`, etc.) — works both on the rendered Pages site and when browsing `/docs` directly on GitHub.

## What you need to do after merge (one-time)

1. Repo Settings → **Pages** → Source: **Deploy from a branch** → Branch: **main**, Folder: **/docs** → Save.
2. Site goes live at `https://magna-nz.github.io/aspnetcore-debugger-mcp/` within a couple of minutes.

(Until you flip the switch, the docs are just markdown — fully readable on GitHub.)

Linear: MAG-43

🤖 Generated with [Claude Code](https://claude.com/claude-code)