### PR TITLE
README: 2 conversation examples + de-jargon (MAG-44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,16 @@ with variables — without you setting any breakpoint manually.
 
 > I'll run your app and stop inside the handler when the request hits.
 >
-> Walked through `UserController.GetUser` → `UserService.GetUserAsync` →
-> `UserRepository.GetByIdAsync`. Here's the query the repo is issuing against the DB:
+> I followed the call from the controller into the user service and then into the repository.
+> Here's the query the repo is issuing against the DB:
 >
 > ```
 > SELECT * FROM users WHERE id = '42'
 > ```
 >
-> That's the bug — the `id` is being string-interpolated into the SQL, but the `id` column is
-> an `int`. Postgres returns zero rows for that comparison. Fix is to parameterise the query
-> and pass `id` as an int.
+> That's the bug — the `id` is being dropped into the SQL as text instead of as a value, but
+> the `id` column is an `int`. Postgres returns zero rows for that comparison. Fix is to use a
+> parameter for the id and pass it as an int.
 
 ### Why did my app throw?
 
@@ -48,7 +48,7 @@ with variables — without you setting any breakpoint manually.
 
 **Claude**
 
-> I'll set a break on unhandled exceptions and trigger the flow. Caught it.
+> I'll catch any unhandled exception and run through your checkout flow. Caught it.
 >
 > ```
 > Thrown at OrderService.cs:67
@@ -62,7 +62,7 @@ with variables — without you setting any breakpoint manually.
 > ```
 >
 > `LoadCart(userId)` on line 62 returned a `Cart` whose `Items` is `null` for new users — and
-> the null check on line 65 only guards `cart`, not `cart.Items`. Two fix options:
+> the null check on line 65 only checks `cart` itself, not `cart.Items`. Two fix options:
 > initialise `Items = []` in the `Cart` constructor, or use `cart.Items ?? []` on line 67.
 
 [See 5 more →](docs/examples.md)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 **An MIT-licensed [Model Context Protocol](https://modelcontextprotocol.io/) server that lets an
-AI agent (Claude, etc.) debug your .NET / ASP.NET Core app — conversationally.**
+AI agent (Claude, etc.) debug your .NET / ASP.NET Core app.**
 
 Instead of *"I think the bug is around line 42, try this"*, the agent runs your code, pauses it,
 reads the actual runtime values, mutates state to test a fix, and answers grounded in what it
@@ -17,24 +17,55 @@ actually saw.
 autopsy, hang analysis, and **server-side request tracing** that captures the full call chain
 with variables — without you setting any breakpoint manually.
 
-## A taste — real output
+## See it in action
 
-You tell Claude *"trace what `GET /order/42` does"* and the agent traces 5 methods, hits the
-endpoint, and returns:
+### Why is my endpoint returning null?
 
-```
-[+  679ms] → OrderController.GetOrder()       id=42, data=null
-[+  711ms] --→ OrderService.LookupOrder()     id=42, raw=null, enriched=null
-[+  735ms] ----→ OrderRepository.FetchById()  id=42
-[+  759ms] ------→ SqlClient.ExecuteQuery()   sql="SELECT * FROM orders WHERE id = 42"
-[+  783ms] ----→ EnrichmentService.Enrich()   raw="rows(sql=SELECT * FROM orders WHERE id …"
-```
+**You**
 
-— Controller → Service → Repository → SqlClient (4 levels), with `Enrich` correctly shown as a
-sibling of the Repository call at depth 2. Each line is one captured method entry with its
-actual locals. No breakpoints set manually.
+> `GET /users/42` is returning null. Can you figure out why?
 
-[See 6 more worked examples →](docs/examples.md)
+**Claude**
+
+> I'll run your app and stop inside the handler when the request hits.
+>
+> Walked through `UserController.GetUser` → `UserService.GetUserAsync` →
+> `UserRepository.GetByIdAsync`. Here's the query the repo is issuing against the DB:
+>
+> ```
+> SELECT * FROM users WHERE id = '42'
+> ```
+>
+> That's the bug — the `id` is being string-interpolated into the SQL, but the `id` column is
+> an `int`. Postgres returns zero rows for that comparison. Fix is to parameterise the query
+> and pass `id` as an int.
+
+### Why did my app throw?
+
+**You**
+
+> My `/checkout` endpoint throws a `NullReferenceException` somewhere. Find it.
+
+**Claude**
+
+> I'll set a break on unhandled exceptions and trigger the flow. Caught it.
+>
+> ```
+> Thrown at OrderService.cs:67
+>
+>   65: if (cart == null) throw new ArgumentNullException(nameof(cart));
+>   66: var total = 0m;
+> → 67: foreach (var item in cart.Items) total += item.Price;
+>
+> At the throw:
+>   cart.Items = null
+> ```
+>
+> `LoadCart(userId)` on line 62 returned a `Cart` whose `Items` is `null` for new users — and
+> the null check on line 65 only guards `cart`, not `cart.Items`. Two fix options:
+> initialise `Items = []` in the `Cart` constructor, or use `cart.Items ?? []` on line 67.
+
+[See 5 more →](docs/examples.md)
 
 ## How it works
 
@@ -80,18 +111,6 @@ A protocol bridge with agent-friendly composites on top — `exception_autopsy`,
 4. **Just chat with Claude.** `/mcp` confirms it's connected. From there, describe what you want — *"why does this endpoint return null"* — and the agent picks the right tools.
 
 [Full install + troubleshooting →](docs/install.md)
-
-## Tools at a glance
-
-| Category | Tools |
-|---|---|
-| **Session** | launch / attach / disconnect / state |
-| **Breakpoints** | line (conditional/hit-count/logpoint), function, exception, data, remove, list |
-| **Execution** | continue / pause / step / blocking wait-for-stop |
-| **Inspection** | threads / stack / variables / evaluate / set-variable / **`stack_explore` composite** |
-| **Diagnostics** | **`exception_autopsy`** · **`hang_analyze`** · **`trace_start/get/stop`** · stdout drain |
-
-26 tools total. [Full reference with parameters →](docs/tools.md)
 
 ## Docs
 


### PR DESCRIPTION
## Summary

PR #11 was merged before these two follow-up commits landed on the branch. They never made it into main. This PR carries them over — only the README changes, no other files touched.

## What's in this PR (2 commits, README only, +46 / -27)

**\`a520971\` — replace the single trace-tree example with 2 conversation examples; drop the "Tools at a glance" table; less AI-ish wording**

- Replaces the single \`## A taste — real output\` section (the OrderController trace tree) with two \`## See it in action\` conversations, formatted as **You** / **Claude** dialogue blocks matching docs/examples.md:
  - *"Why is `GET /users/42` returning null?"* — agent walks through Controller → Service → Repository, spots a string-vs-int SQL bug
  - *"My `/checkout` endpoint throws a NullReferenceException somewhere. Find it."* — agent catches the unhandled exception, returns the throw site with source snippet + locals + fix suggestions
- Removes the "Tools at a glance" table — same info already lives in docs/tools.md (linked from the Docs section).
- Strips "— conversationally" from the lead paragraph and "— real output" from the example heading. Both phrasings were doing nothing except making the prose sound auto-generated.

**\`44078a1\` — de-jargon the example responses**

Five phrase swaps so the **Claude** replies read like natural conversation rather than debugger / DB lingo:

| Was | Now |
|---|---|
| "Walked through Controller → Service → Repository" | "I followed the call from the controller into the user service and then into the repository" |
| "string-interpolated into the SQL" | "dropped into the SQL as text instead of as a value" |
| "parameterise the query" | "use a parameter for the id" |
| "set a break on unhandled exceptions and trigger the flow" | "catch any unhandled exception and run through your checkout flow" |
| "the null check only guards \`cart\`" | "the null check only checks \`cart\` itself" |

Linear: MAG-44

🤖 Generated with [Claude Code](https://claude.com/claude-code)