### PR TITLE
Fix CODEOWNERS username typo (MAG-45)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @magna_nz
+* @magna-nz


### PR DESCRIPTION
## Summary

`.github/CODEOWNERS` had `@magna_nz` (underscore). GitHub usernames don't contain underscores — the real handle is `magna-nz` (hyphen). GitHub silently ignores unmatched entries, so the file was effectively a no-op: no auto-review request when a PR opens.

One-character diff: `_` → `-`.

After merge, every new PR auto-requests @magna-nz as a reviewer.

Linear: MAG-45

🤖 Generated with [Claude Code](https://claude.com/claude-code)