### PR TITLE
Improve NuGet package metadata and repo discoverability (MAG-46)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -54,14 +54,13 @@
   Roslyn code navigation is out of scope.
 
 ## Where we left off
-- ALL 5 WAVES COMPLETE on branch `feature/MAG-39-debugger-mcp`. Linear ticket: MAG-39.
-- 22 MCP tools live, 44 unit tests passing, end-to-end smoke for every wave passes, NuGet
-  package builds, README done, CI defined.
-- Awaiting decision on raising the PR.
+- MAG-46 (NuGet metadata + discoverability) complete. PR #14 open, awaiting merge.
+- Branch: `feature/MAG-46-nuget-metadata-discoverability`
 
 ## What's next
-1. Raise the PR (one branch, one PR, all 5 waves) — needs user confirmation.
-2. Decide whether to publish the NuGet package (and to what feed) — out of scope for the PR.
+1. Merge PR #14 once approved.
+2. Mark MAG-46 done after merge.
+3. Decide whether to publish the NuGet package (and to what feed).
 
 ## Gotchas
 - cmake 4.x: configured with `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` for old `cmake_minimum_required`.

--- a/src/AspNetCoreDebuggerMcp/AspNetCoreDebuggerMcp.csproj
+++ b/src/AspNetCoreDebuggerMcp/AspNetCoreDebuggerMcp.csproj
@@ -16,13 +16,14 @@
 
     <!-- NuGet metadata -->
     <Authors>magna-nz</Authors>
-    <Description>MIT-licensed Model Context Protocol server that gives AI agents interactive .NET debugging by wrapping netcoredbg (Samsung) over the Debug Adapter Protocol. 22 tools across session management, breakpoints, execution, inspection, evaluation, exception analysis, hang detection, and process output.</Description>
+    <Title>ASP.NET Core Debugger — MCP Server for AI Agents</Title>
+    <Description>MIT-licensed MCP (Model Context Protocol) server that gives AI agents (Claude, Cursor, Copilot, etc.) interactive .NET / ASP.NET Core debugging. Wraps Samsung's netcoredbg over the Debug Adapter Protocol (DAP). 26 tools: launch/attach, breakpoints (line, function, exception, data), stepping, thread inspection, stack traces, expression evaluation, variable mutation, exception autopsy, hang/deadlock analysis, server-side request tracing, and process output capture. Install as a .NET global tool and point any MCP-compatible AI at your running app.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/magna-nz/aspnetcore-debugger-mcp</PackageProjectUrl>
     <RepositoryUrl>https://github.com/magna-nz/aspnetcore-debugger-mcp</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageTags>mcp;mcp-server;debugger;dotnet;netcoredbg;dap;ai;ai-agent;debugging;breakpoints;aspnetcore</PackageTags>
+    <PackageTags>mcp;mcp-server;model-context-protocol;debugger;debugging;dotnet;dotnet-tool;net10;csharp;aspnetcore;netcoredbg;dap;debug-adapter-protocol;ai;ai-agent;claude;cursor;llm;breakpoints;inspection;exception;hang;deadlock</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Added `<Title>` element to csproj for human-readable NuGet display: *ASP.NET Core Debugger — MCP Server for AI Agents*
- Updated `<Description>`: corrects tool count (22→26), lists capabilities, names target AI clients (Claude, Cursor, Copilot), includes DAP/MCP keywords for search indexing
- Expanded `<PackageTags>` from 11 to 23: added `model-context-protocol`, `dotnet-tool`, `net10`, `csharp`, `debug-adapter-protocol`, `claude`, `cursor`, `llm`, `inspection`, `exception`, `hang`, `deadlock`
- Updated GitHub repo topics via `gh` CLI: removed `performance` and `runtime` (too generic), added `netcoredbg`, `mcp-server`, `ai-agent`, `dotnet-tool`, `debug-adapter-protocol`

## Test plan

- [ ] Verify `dotnet pack` still succeeds and the `.nupkg` is valid
- [ ] Check NuGet.org package page renders Title and Description correctly after publish

Closes MAG-46

🤖 Generated with [Claude Code](https://claude.com/claude-code)