### PR TITLE
Bundle netcoredbg binaries — drop manual install step (MAG-47)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
           dotnet-version: '10.0.x'
           dotnet-quality: 'ga'
 
+      - name: Fetch bundled netcoredbg binaries
+        run: bash scripts/fetch-netcoredbg-binaries.sh
+
       - name: Restore
         run: dotnet restore
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,9 @@ jobs:
           echo "version=$v" >> "$GITHUB_OUTPUT"
           echo "Resolved version: $v"
 
+      - name: Fetch bundled netcoredbg binaries
+        run: bash scripts/fetch-netcoredbg-binaries.sh
+
       - name: Restore
         run: dotnet restore
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ artifacts/
 .netcoredbg-build/
 external/netcoredbg/build/
 
+# Bundled netcoredbg binaries — populated by scripts/fetch-netcoredbg-binaries.sh
+# (CI runs this before `dotnet pack`). Out of git to keep repo light.
+src/AspNetCoreDebuggerMcp/runtimes/
+
 # OS
 .DS_Store
 

--- a/README.md
+++ b/README.md
@@ -85,36 +85,34 @@ target .NET process
 A protocol bridge with agent-friendly composites on top — `exception_autopsy`, `stack_explore`,
 `hang_analyze`, and the trace tools — that bundle multiple DAP requests into a single tool call.
 
-## Use it in 4 steps
+## Use it in 3 steps
 
-1. **Install prerequisites** — .NET 10 SDK + `netcoredbg` ([prebuilt for Linux/Win/Intel macOS](https://github.com/Samsung/netcoredbg/releases) · [build for macOS arm64](docs/macos-arm64.md))
-2. **Install the tool** — `dotnet tool install -g AspNetCoreDebuggerMcp --prerelease`
-3. **Register with Claude** — either the quick CLI command:
+1. **Install the tool** — needs the [.NET 10 SDK](https://dotnet.microsoft.com/download).
    ```bash
-   claude mcp add aspnetcore-debugger \
-     -e NETCOREDBG_PATH=/path/to/netcoredbg \
-     -- aspnetcore-debugger-mcp
+   dotnet tool install -g AspNetCoreDebuggerMcp --prerelease
+   ```
+   The package bundles prebuilt `netcoredbg` for `linux-x64`, `linux-arm64`, `win-x64`, `osx-x64`, and `osx-arm64` — no separate install needed.
+2. **Register with Claude** — either the quick CLI command:
+   ```bash
+   claude mcp add aspnetcore-debugger -- aspnetcore-debugger-mcp
    ```
    …or edit `.mcp.json` (project-scoped) / `~/.claude.json` (global) / `claude_desktop_config.json` (Claude Desktop) directly:
    ```json
    {
      "mcpServers": {
        "aspnetcore-debugger": {
-         "command": "aspnetcore-debugger-mcp",
-         "env": {
-           "NETCOREDBG_PATH": "/absolute/path/to/netcoredbg"
-         }
+         "command": "aspnetcore-debugger-mcp"
        }
      }
    }
    ```
-4. **Just chat with Claude.** `/mcp` confirms it's connected. From there, describe what you want — *"why does this endpoint return null"* — and the agent picks the right tools.
+3. **Just chat with Claude.** `/mcp` confirms it's connected. From there, describe what you want — *"why does this endpoint return null"* — and the agent picks the right tools.
 
 [Full install + troubleshooting →](docs/install.md)
 
 ## Docs
 
-- **[Install & configure](docs/install.md)** — 4 steps, both Claude Code & Desktop, troubleshooting
+- **[Install & configure](docs/install.md)** — 3 steps, both Claude Code & Desktop, troubleshooting
 - **[What you can do with it](docs/examples.md)** — 7 things you can ask Claude to do for you
 - **[Full tool reference](docs/tools.md)** — every parameter on every tool
 - **[Known limits](docs/limits.md)** — when *not* to use this tool, adapter & tracing limits

--- a/SPEC.md
+++ b/SPEC.md
@@ -63,6 +63,23 @@ target .NET process
 - Linux and Windows are expected to work afterward with little extra effort (netcoredbg ships
   prebuilt binaries for both).
 
+## Bundled netcoredbg
+
+The NuGet package ships prebuilt netcoredbg binaries for five RIDs:
+`linux-x64`, `linux-arm64`, `win-x64`, `osx-x64`, `osx-arm64`. They live in the package under
+`runtimes/<rid>/native/netcoredbg[.exe]`. At startup the tool resolves the bundled binary by
+detecting the host RID (via `RuntimeInformation` OS + `ProcessArchitecture`).
+
+Resolution order:
+1. `NETCOREDBG_PATH` env var — escape hatch for custom builds
+2. Bundled binary at `<AppContext.BaseDirectory>/runtimes/<rid>/native/netcoredbg[.exe]`
+3. `netcoredbg` on PATH
+4. Throw with a clear error
+
+The netcoredbg version is pinned (Samsung release tag); bumps are deliberate. The Samsung-prebuilt
+RIDs (x64s + linux-arm64) come from the official release; `osx-arm64` is our own build, uploaded
+as a release asset because Samsung does not ship one.
+
 ## Tools
 
 ### Session

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -7,11 +7,15 @@ git clone https://github.com/magna-nz/aspnetcore-debugger-mcp.git
 cd aspnetcore-debugger-mcp
 dotnet build
 dotnet test
-NETCOREDBG_PATH=/path/to/netcoredbg dotnet run --project src/AspNetCoreDebuggerMcp
+
+# Fetch bundled netcoredbg binaries (one-time per checkout, ~30s) so the tool
+# can run end-to-end against a real target.
+bash scripts/fetch-netcoredbg-binaries.sh
+dotnet run --project src/AspNetCoreDebuggerMcp
 ```
 
-Requires .NET 10 SDK + `netcoredbg` on your machine (see [Install](install.md) and
-[macOS arm64 build](macos-arm64.md)).
+Requires .NET 10 SDK. The unit tests don't need netcoredbg (locator resolution is mocked); only
+end-to-end runs do.
 
 ## Project layout
 
@@ -34,7 +38,11 @@ tests/AspNetCoreDebuggerMcp.Tests/    # 80+ xUnit unit tests
 ├── ci.yml                  # Linux + macOS build/test/pack on every push and PR
 └── release.yml             # On GitHub Release published: pack + attach + push to NuGet
 scripts/
-└── build-netcoredbg-macos-arm64.sh    # Builds netcoredbg natively for Apple Silicon
+├── fetch-netcoredbg-binaries.sh        # Downloads bundled netcoredbg for all 5 RIDs (CI runs this)
+├── package-netcoredbg-osx-arm64.sh     # Packages a local arm64 build into a Samsung-layout tarball
+├── build-netcoredbg-macos-arm64.sh     # Builds netcoredbg natively for Apple Silicon (for the bundled binary)
+└── smoke-test-bundled-binary.sh        # E2E check: bundled netcoredbg speaks DAP against SampleWebApi
+tests/fixtures/SampleWebApi/            # Tiny ASP.NET Core 10 web API used by the smoke test
 ```
 
 ## Architecture in one sentence
@@ -51,15 +59,16 @@ The repository's end-to-end demos live in the developer's local job dir during d
 unit tests are the canonical "this works" signal. To exercise the full pipeline manually:
 
 ```bash
-# 1. Build a tiny ASP.NET Core test app
-dotnet new web -o /tmp/Demo
-# (write a small Program.cs handler)
+# 1. Stage the bundled netcoredbg binaries (one-time)
+bash scripts/fetch-netcoredbg-binaries.sh
 
-# 2. Run the MCP server pointing at netcoredbg
-NETCOREDBG_PATH=~/projects/netcoredbg-src/bin/netcoredbg \
-  dotnet run --project src/AspNetCoreDebuggerMcp
+# 2. Verify the bundled binary works end-to-end
+bash scripts/smoke-test-bundled-binary.sh
 
-# 3. From an MCP client (or a script), call debug_launch / breakpoint_set / etc.
+# 3. Run the MCP server (no NETCOREDBG_PATH needed — it picks the bundled binary)
+dotnet run --project src/AspNetCoreDebuggerMcp
+
+# 4. From an MCP client (or a script), call debug_launch / breakpoint_set / etc.
 ```
 
 ## Pull requests

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,52 +1,36 @@
 # Install & configure
 
-Once per machine: install prerequisites and the tool. Once per project: register it. Then just chat.
+Once per machine: install the tool. Once per project: register it. Then just chat.
 
-## Step 1 — Prerequisites *(once per machine)*
+## Step 1 — Install the MCP server *(once per machine)*
 
-- **.NET 10 SDK** — [dotnet.microsoft.com/download](https://dotnet.microsoft.com/download)
-- **netcoredbg** — Samsung's MIT-licensed .NET debugger that this server drives:
-
-  | Platform | Get it from |
-  |---|---|
-  | Linux x64 / arm64 | [Samsung release](https://github.com/Samsung/netcoredbg/releases) — extract anywhere |
-  | Windows x64 | [Samsung release](https://github.com/Samsung/netcoredbg/releases) — extract anywhere |
-  | macOS Intel (x64) | [Samsung release](https://github.com/Samsung/netcoredbg/releases) — extract anywhere |
-  | **macOS Apple Silicon (arm64)** | No prebuilt — see [Building netcoredbg on macOS arm64](macos-arm64.md) |
-
-  Tell the server where the binary lives via one of:
-  - Set `NETCOREDBG_PATH` to its absolute path *(recommended)*
-  - Put `netcoredbg` on your `PATH`
-  - Place it next to this tool's assembly
-- **Claude Code** or **Claude Desktop** installed.
-
-## Step 2 — Install the MCP server *(once per machine)*
+Needs the **.NET 10 SDK** ([download](https://dotnet.microsoft.com/download)).
 
 ```bash
 dotnet tool install -g AspNetCoreDebuggerMcp --prerelease
 ```
 
-`--prerelease` is needed while the version is `0.1.0-preview` (or any `-preview`/`-rc` suffix). Drop it once a stable `1.0.0` ships.
+`--prerelease` is needed while the version is `0.x` (or any `-preview`/`-rc` suffix). Drop it once a stable `1.0.0` ships.
+
+The package ships prebuilt `netcoredbg` (Samsung's MIT-licensed .NET debugger) for **linux-x64, linux-arm64, win-x64, osx-x64, osx-arm64**. The tool auto-detects your platform at startup — no separate install needed.
 
 That puts the `aspnetcore-debugger-mcp` binary on your `PATH`. Verify:
 
 ```bash
-NETCOREDBG_PATH=/path/to/netcoredbg aspnetcore-debugger-mcp
+aspnetcore-debugger-mcp
 # starts and idles on stdin; Ctrl-C to exit
 ```
 
-If it errors with *"netcoredbg not found"*, the env var or PATH isn't pointing at the binary — re-check Step 1.
+If it errors with *"netcoredbg not found"*, see [Troubleshooting](#troubleshooting) below.
 
-## Step 3 — Register with your MCP client *(once per project, or globally)*
+## Step 2 — Register with your MCP client *(once per project, or globally)*
 
 ### Claude Code
 
 Either CLI:
 
 ```bash
-claude mcp add aspnetcore-debugger \
-  -e NETCOREDBG_PATH=/path/to/netcoredbg \
-  -- aspnetcore-debugger-mcp
+claude mcp add aspnetcore-debugger -- aspnetcore-debugger-mcp
 ```
 
 Or edit `.mcp.json` (project) / `~/.claude.json` (global):
@@ -55,8 +39,7 @@ Or edit `.mcp.json` (project) / `~/.claude.json` (global):
 {
   "mcpServers": {
     "aspnetcore-debugger": {
-      "command": "aspnetcore-debugger-mcp",
-      "env": { "NETCOREDBG_PATH": "/absolute/path/to/netcoredbg" }
+      "command": "aspnetcore-debugger-mcp"
     }
   }
 }
@@ -70,8 +53,7 @@ Edit `claude_desktop_config.json` — same JSON shape goes in the `mcpServers` b
 {
   "mcpServers": {
     "aspnetcore-debugger": {
-      "command": "aspnetcore-debugger-mcp",
-      "env": { "NETCOREDBG_PATH": "/absolute/path/to/netcoredbg" }
+      "command": "aspnetcore-debugger-mcp"
     }
   }
 }
@@ -79,7 +61,7 @@ Edit `claude_desktop_config.json` — same JSON shape goes in the `mcpServers` b
 
 Restart Claude Desktop after editing.
 
-## Step 4 — Just chat with Claude
+## Step 3 — Just chat with Claude
 
 Open Claude Code or Claude Desktop in your .NET project. Run `/mcp` — `aspnetcore-debugger` should show as **connected**.
 
@@ -103,11 +85,27 @@ dotnet tool uninstall -g AspNetCoreDebuggerMcp
 
 Then remove the `aspnetcore-debugger` entry from your MCP client config.
 
+## Using a custom netcoredbg build
+
+The bundled binary is pinned to a specific Samsung release. If you need to use a custom build (e.g. a newer Samsung release, a patched binary, or an unbundled architecture), set `NETCOREDBG_PATH`:
+
+```json
+{
+  "mcpServers": {
+    "aspnetcore-debugger": {
+      "command": "aspnetcore-debugger-mcp",
+      "env": { "NETCOREDBG_PATH": "/absolute/path/to/netcoredbg" }
+    }
+  }
+}
+```
+
+The env var wins over the bundled binary. See [macOS arm64 — building netcoredbg](macos-arm64.md) if you want to build your own.
+
 ## Troubleshooting
 
 | Symptom | Likely cause |
 |---|---|
-| `/mcp` shows the server as failed / disconnected | The `aspnetcore-debugger-mcp` binary isn't on PATH, or `NETCOREDBG_PATH` is wrong. Run the verify command from Step 2 in a regular shell. |
-| Tool calls error with *"netcoredbg not found"* | `NETCOREDBG_PATH` env var not propagating from MCP client config — make sure it's set in the `env` block of the server entry. |
-| First debug session hangs on launch | netcoredbg arm64 macOS build hasn't been built — see [macOS arm64](macos-arm64.md). |
+| `/mcp` shows the server as failed / disconnected | The `aspnetcore-debugger-mcp` binary isn't on PATH. Run the verify command from Step 1 in a regular shell. |
+| Tool calls error with *"netcoredbg not found"* | The bundled binary for your RID couldn't be found — your platform may not be one of the five we bundle. Set `NETCOREDBG_PATH` to a binary you've built or downloaded. |
 | Trace tool errors with "user breakpoints exist" | Trace mode requires no user BPs — call `breakpoint_remove` on each first, or `trace_stop` if a previous trace is still active. |

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -53,4 +53,4 @@ on the stack right now.
 | Setting a breakpoint on a function name doesn't catch it | Use the exact fully-qualified name. For generic methods, include the type parameter (`Foo``1.Bar`). |
 | The trace shows everything at the same depth | Increase the *frames per event* setting so each captured stack reaches your other traced methods. |
 | Variable values are `null` when you expect data | Your breakpoint may have stopped *before* the variable was assigned — check the source snippet that comes back with the stop. |
-| The server shows as disconnected in `/mcp` | The `NETCOREDBG_PATH` env var isn't pointing at the binary. Test it: `NETCOREDBG_PATH=… aspnetcore-debugger-mcp` should start in a regular shell. |
+| The server shows as disconnected in `/mcp` | The `aspnetcore-debugger-mcp` binary isn't on `PATH`. Run `aspnetcore-debugger-mcp` directly in a regular shell — it should start and idle. The bundled `netcoredbg` is resolved automatically. |

--- a/docs/macos-arm64.md
+++ b/docs/macos-arm64.md
@@ -1,7 +1,11 @@
-# macOS Apple Silicon — building netcoredbg
+# macOS Apple Silicon — building netcoredbg (advanced)
 
-Samsung doesn't publish an arm64 macOS prebuilt of netcoredbg. The repo includes a script that
-builds it from source.
+**You don't need this for normal use** — the AspNetCoreDebuggerMcp NuGet package bundles a prebuilt
+arm64 macOS netcoredbg binary that the tool resolves automatically. This page is only relevant if
+you want to build your own (e.g. to track a newer Samsung release than what we ship, or for development).
+
+Samsung doesn't publish an arm64 macOS prebuilt of netcoredbg, so the bundled binary is our own
+build. This repo includes the same script we use to produce it.
 
 ## Prerequisites
 
@@ -43,12 +47,12 @@ The validated-on-arm64 functionality includes: launch, attach, line/function/exc
 breakpoints (with conditions, hit counts, logpoints), step in/over/out, threads, stack traces,
 scopes, variables, evaluate, setExpression, exceptionInfo, output events.
 
-## Why a script instead of a prebuilt binary in this repo?
+## How this is distributed
 
-Distributing a prebuilt unsigned binary in a Git repo brings up signing / notarization /
-gatekeeper friction on Apple Silicon. The build script is small, deterministic, and uses your
-own toolchain — much cleaner than shipping bytes someone else has to trust.
+We run this build script once per netcoredbg release, package the result into a tarball matching
+Samsung's official tarball layout (`scripts/package-netcoredbg-osx-arm64.sh`), and upload it as a
+GitHub release asset on a `vendor-netcoredbg-<version>` tag. The release workflow's
+`scripts/fetch-netcoredbg-binaries.sh` pulls this tarball along with the four Samsung-prebuilt
+RIDs, and `dotnet pack` includes them all under `runtimes/<rid>/native/` in the NuGet package.
 
-If we ever need a quicker install path, the right move is to build the netcoredbg arm64 binary
-in CI and attach it to GitHub Releases — then the MCP server's auto-discover code can fall back
-to a downloaded binary. Not done yet; happy to add it if it's annoying enough.
+End users get the bundled binary automatically — they never have to run this script.

--- a/scripts/fetch-netcoredbg-binaries.sh
+++ b/scripts/fetch-netcoredbg-binaries.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Downloads prebuilt netcoredbg binaries for all supported RIDs and stages them under
+# src/AspNetCoreDebuggerMcp/runtimes/<rid>/native/ for inclusion in the NuGet pack.
+#
+# Pinned version: NETCOREDBG_VERSION below. Bump deliberately when needed.
+#
+# RIDs:
+#   linux-x64, linux-arm64, win-x64, osx-x64 → Samsung official prebuilts
+#   osx-arm64                                → our own build (Samsung doesn't ship one),
+#                                               hosted as a GitHub release asset on this repo
+#
+# Usage:
+#   scripts/fetch-netcoredbg-binaries.sh
+#
+# Env vars (override defaults):
+#   NETCOREDBG_VERSION       Samsung release tag (default: 3.1.3-1062)
+#   OSX_ARM64_BUNDLE_URL     URL to our osx-arm64 tarball (default: GitHub release asset on this repo)
+
+set -euo pipefail
+
+NETCOREDBG_VERSION="${NETCOREDBG_VERSION:-3.1.3-1062}"
+SAMSUNG_BASE="https://github.com/Samsung/netcoredbg/releases/download/${NETCOREDBG_VERSION}"
+OSX_ARM64_BUNDLE_URL="${OSX_ARM64_BUNDLE_URL:-https://github.com/magna-nz/aspnetcore-debugger-mcp/releases/download/vendor-netcoredbg-${NETCOREDBG_VERSION}/netcoredbg-osx-arm64.tar.gz}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+RUNTIMES_DIR="${REPO_ROOT}/src/AspNetCoreDebuggerMcp/runtimes"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+log() { echo "[fetch-netcoredbg] $*"; }
+
+# fetch_and_stage <rid> <asset_url> <archive_kind: tar.gz|zip>
+fetch_and_stage() {
+    local rid="$1"
+    local url="$2"
+    local kind="$3"
+    local dest="${RUNTIMES_DIR}/${rid}/native"
+
+    log "Fetching ${rid} from ${url}"
+    rm -rf "${dest}"
+    mkdir -p "${dest}"
+
+    local archive="${TMP_DIR}/${rid}.${kind}"
+    if ! curl -fSL "${url}" -o "${archive}"; then
+        echo "ERROR: download failed for ${rid}: ${url}" >&2
+        return 1
+    fi
+
+    local extract_dir="${TMP_DIR}/${rid}-extracted"
+    mkdir -p "${extract_dir}"
+    case "${kind}" in
+        tar.gz) tar -xzf "${archive}" -C "${extract_dir}" ;;
+        zip)    unzip -q "${archive}" -d "${extract_dir}" ;;
+        *)      echo "ERROR: unknown archive kind: ${kind}" >&2; return 1 ;;
+    esac
+
+    # Samsung tarballs and our osx-arm64 tarball wrap files in a netcoredbg/ folder.
+    local inner="${extract_dir}/netcoredbg"
+    if [[ ! -d "${inner}" ]]; then
+        echo "ERROR: expected ${inner}/ inside ${archive}" >&2
+        ls -la "${extract_dir}" >&2
+        return 1
+    fi
+
+    cp -R "${inner}/." "${dest}/"
+
+    # Ensure native binary is executable on Unix-like platforms.
+    if [[ "${rid}" != win-* ]] && [[ -f "${dest}/netcoredbg" ]]; then
+        chmod +x "${dest}/netcoredbg"
+    fi
+}
+
+main() {
+    mkdir -p "${RUNTIMES_DIR}"
+
+    fetch_and_stage "linux-x64"   "${SAMSUNG_BASE}/netcoredbg-linux-amd64.tar.gz" tar.gz
+    fetch_and_stage "linux-arm64" "${SAMSUNG_BASE}/netcoredbg-linux-arm64.tar.gz" tar.gz
+    fetch_and_stage "osx-x64"     "${SAMSUNG_BASE}/netcoredbg-osx-amd64.tar.gz"  tar.gz
+    fetch_and_stage "win-x64"     "${SAMSUNG_BASE}/netcoredbg-win64.zip"          zip
+    fetch_and_stage "osx-arm64"   "${OSX_ARM64_BUNDLE_URL}"                       tar.gz
+
+    log "Verifying all 5 RIDs are populated…"
+    local missing=0
+    for rid in linux-x64 linux-arm64 osx-x64 osx-arm64; do
+        if [[ ! -x "${RUNTIMES_DIR}/${rid}/native/netcoredbg" ]]; then
+            echo "MISSING: ${RUNTIMES_DIR}/${rid}/native/netcoredbg" >&2
+            missing=1
+        fi
+    done
+    if [[ ! -f "${RUNTIMES_DIR}/win-x64/native/netcoredbg.exe" ]]; then
+        echo "MISSING: ${RUNTIMES_DIR}/win-x64/native/netcoredbg.exe" >&2
+        missing=1
+    fi
+    if [[ "${missing}" -ne 0 ]]; then
+        exit 1
+    fi
+
+    log "Done. netcoredbg ${NETCOREDBG_VERSION} staged under ${RUNTIMES_DIR}"
+}
+
+main "$@"

--- a/scripts/package-netcoredbg-osx-arm64.sh
+++ b/scripts/package-netcoredbg-osx-arm64.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Packages a locally-built netcoredbg (macOS arm64) into a tarball matching
+# Samsung's official tarball layout so it can be uploaded as a GitHub release asset
+# and consumed by scripts/fetch-netcoredbg-binaries.sh.
+#
+# Prerequisites:
+#   - Apple Silicon (arm64) macOS
+#   - netcoredbg already built — defaults to ~/projects/netcoredbg-src/build,
+#     override with NETCOREDBG_BUILD_DIR.
+#
+# Produces: ./netcoredbg-osx-arm64.tar.gz containing:
+#   netcoredbg/netcoredbg
+#   netcoredbg/ManagedPart.dll
+#   netcoredbg/libdbgshim.dylib
+#   netcoredbg/Microsoft.CodeAnalysis.*.dll
+#
+# Upload manually:
+#   gh release create vendor-netcoredbg-3.1.3-1062 netcoredbg-osx-arm64.tar.gz \
+#     --title "Bundled netcoredbg vendor binaries (3.1.3-1062)" \
+#     --notes "macOS arm64 build of Samsung/netcoredbg ${NETCOREDBG_VERSION}, since Samsung does not ship a prebuilt for this RID."
+
+set -euo pipefail
+
+NETCOREDBG_BUILD_DIR="${NETCOREDBG_BUILD_DIR:-$HOME/projects/netcoredbg-src/build}"
+OUT_DIR="${OUT_DIR:-$(pwd)}"
+
+if [[ "$(uname -s)" != "Darwin" ]] || [[ "$(uname -m)" != "arm64" ]]; then
+    echo "This script must run on Apple Silicon macOS (arm64)." >&2
+    exit 1
+fi
+
+SRC_DIR="${NETCOREDBG_BUILD_DIR}/src"
+BIN="${SRC_DIR}/netcoredbg"
+
+if [[ ! -x "${BIN}" ]]; then
+    echo "netcoredbg binary not found at ${BIN}" >&2
+    echo "Build it first: scripts/build-netcoredbg-macos-arm64.sh" >&2
+    exit 1
+fi
+
+STAGE_DIR="$(mktemp -d)"
+trap 'rm -rf "${STAGE_DIR}"' EXIT
+
+INNER="${STAGE_DIR}/netcoredbg"
+mkdir -p "${INNER}"
+
+cp "${BIN}" "${INNER}/netcoredbg"
+
+# Required runtime dependencies — mirror what Samsung's official tarball contains.
+for f in \
+    ManagedPart.dll \
+    Microsoft.CodeAnalysis.dll \
+    Microsoft.CodeAnalysis.CSharp.dll \
+    Microsoft.CodeAnalysis.Scripting.dll \
+    Microsoft.CodeAnalysis.CSharp.Scripting.dll; do
+    if [[ -f "${SRC_DIR}/${f}" ]]; then
+        cp "${SRC_DIR}/${f}" "${INNER}/${f}"
+    else
+        echo "WARNING: ${SRC_DIR}/${f} not found — skipping" >&2
+    fi
+done
+
+# dbgshim ships as libdbgshim.dylib on macOS; find wherever it landed.
+DBGSHIM=$(find "${NETCOREDBG_BUILD_DIR}" -name "libdbgshim.dylib" -print -quit 2>/dev/null || true)
+if [[ -n "${DBGSHIM}" ]] && [[ -f "${DBGSHIM}" ]]; then
+    cp "${DBGSHIM}" "${INNER}/libdbgshim.dylib"
+else
+    echo "WARNING: libdbgshim.dylib not found in build tree" >&2
+fi
+
+chmod +x "${INNER}/netcoredbg"
+
+OUT="${OUT_DIR}/netcoredbg-osx-arm64.tar.gz"
+tar -czf "${OUT}" -C "${STAGE_DIR}" netcoredbg
+
+echo "Created: ${OUT}"
+echo "Contents:"
+tar -tzf "${OUT}" | sed 's/^/  /'

--- a/scripts/smoke-test-bundled-binary.sh
+++ b/scripts/smoke-test-bundled-binary.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Smoke test: verify the bundled netcoredbg works end-to-end against a real
+# ASP.NET Core Web API.
+#
+# Steps:
+#   1. Build the SampleWebApi fixture
+#   2. Spawn the bundled netcoredbg (resolved by current RID) in DAP mode
+#   3. Send a DAP `initialize` request and verify a well-formed response
+#
+# This proves the bundled binary launches and speaks DAP for the host RID.
+# Run after fetch-netcoredbg-binaries.sh has staged the binaries.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+RUNTIMES_DIR="${REPO_ROOT}/src/AspNetCoreDebuggerMcp/runtimes"
+FIXTURE_DIR="${REPO_ROOT}/tests/fixtures/SampleWebApi"
+
+log() { echo "[smoke] $*"; }
+
+# Resolve current RID using the same logic as NetcoredbgLocator.
+case "$(uname -s)" in
+    Darwin) os="osx" ;;
+    Linux)  os="linux" ;;
+    MINGW*|CYGWIN*|MSYS*) os="win" ;;
+    *) echo "Unsupported OS: $(uname -s)" >&2; exit 1 ;;
+esac
+case "$(uname -m)" in
+    x86_64|amd64) arch="x64" ;;
+    arm64|aarch64) arch="arm64" ;;
+    *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;;
+esac
+RID="${os}-${arch}"
+EXE_NAME="netcoredbg"
+[[ "${os}" == "win" ]] && EXE_NAME="netcoredbg.exe"
+
+BUNDLED="${RUNTIMES_DIR}/${RID}/native/${EXE_NAME}"
+if [[ ! -x "${BUNDLED}" ]]; then
+    echo "Bundled binary not found: ${BUNDLED}" >&2
+    echo "Run scripts/fetch-netcoredbg-binaries.sh first." >&2
+    exit 1
+fi
+log "Using bundled netcoredbg: ${BUNDLED}"
+"${BUNDLED}" --version | head -1
+
+log "Building SampleWebApi fixture…"
+dotnet build "${FIXTURE_DIR}" -c Debug -v quiet > /tmp/smoke-build.log 2>&1 || {
+    cat /tmp/smoke-build.log >&2
+    exit 1
+}
+DLL="${FIXTURE_DIR}/bin/Debug/net10.0/SampleWebApi.dll"
+[[ -f "${DLL}" ]] || { echo "Built DLL not found: ${DLL}" >&2; exit 1; }
+log "Built: ${DLL}"
+
+log "Sending DAP initialize to netcoredbg via stdio…"
+
+# DAP wire format: Content-Length: <n>\r\n\r\n<JSON>. We send `initialize`
+# and read back netcoredbg's first response. Use python for clean stdio
+# framing — bash quoting is painful for this.
+python3 - "${BUNDLED}" "${DLL}" <<'PY'
+import json, os, subprocess, sys, threading, queue, time
+
+netcoredbg, dll = sys.argv[1], sys.argv[2]
+
+stderr_log = open("/tmp/smoke-netcoredbg.stderr", "wb")
+proc = subprocess.Popen(
+    [netcoredbg, "--interpreter=vscode"],
+    stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=stderr_log,
+    bufsize=0,
+)
+
+def send(obj):
+    body = json.dumps(obj).encode("utf-8")
+    header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
+    proc.stdin.write(header + body)
+    proc.stdin.flush()
+
+q = queue.Queue()
+def reader():
+    buf = b""
+    fd = proc.stdout.fileno()
+    while True:
+        try:
+            chunk = os.read(fd, 4096)
+        except OSError:
+            break
+        if not chunk:
+            break
+        buf += chunk
+        while b"\r\n\r\n" in buf:
+            head, _, rest = buf.partition(b"\r\n\r\n")
+            length = None
+            for line in head.split(b"\r\n"):
+                if line.lower().startswith(b"content-length:"):
+                    length = int(line.split(b":")[1].strip())
+            if length is None or len(rest) < length:
+                buf = head + b"\r\n\r\n" + rest
+                break
+            body = rest[:length]
+            buf = rest[length:]
+            try:
+                q.put(json.loads(body.decode("utf-8")))
+            except Exception:
+                pass
+
+t = threading.Thread(target=reader, daemon=True); t.start()
+
+send({"seq": 1, "type": "request", "command": "initialize",
+      "arguments": {"clientID": "smoke", "adapterID": "coreclr",
+                    "linesStartAt1": True, "columnsStartAt1": True,
+                    "pathFormat": "path"}})
+
+deadline = time.time() + 10
+got_initialize_response = False
+while time.time() < deadline:
+    try:
+        msg = q.get(timeout=1)
+    except queue.Empty:
+        continue
+    if msg.get("type") == "response" and msg.get("command") == "initialize":
+        got_initialize_response = True
+        print(f"[smoke] initialize response: success={msg.get('success')}, body keys={list((msg.get('body') or {}).keys())[:6]}")
+        break
+
+proc.terminate()
+try:
+    proc.wait(timeout=2)
+except subprocess.TimeoutExpired:
+    proc.kill()
+
+if not got_initialize_response:
+    print("[smoke] FAIL: no initialize response within 10s", file=sys.stderr)
+    sys.exit(1)
+print("[smoke] PASS: bundled netcoredbg speaks DAP")
+PY
+
+log "Smoke test passed."

--- a/src/AspNetCoreDebuggerMcp/AspNetCoreDebuggerMcp.csproj
+++ b/src/AspNetCoreDebuggerMcp/AspNetCoreDebuggerMcp.csproj
@@ -30,7 +30,9 @@
   <ItemGroup>
     <None Include="../../README.md" Pack="true" PackagePath="" />
     <None Include="icon.png" Pack="true" PackagePath="" />
-    <None Include="runtimes/**/*" Pack="true" PackagePath="tools/net10.0/any/runtimes/" CopyToOutputDirectory="PreserveNewest" />
+    <!-- Bundled netcoredbg binaries are populated by scripts/fetch-netcoredbg-binaries.sh.
+         PackAsTool copies CopyToOutputDirectory content into tools/net10.0/any/ automatically. -->
+    <None Include="runtimes/**/*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNetCoreDebuggerMcp/AspNetCoreDebuggerMcp.csproj
+++ b/src/AspNetCoreDebuggerMcp/AspNetCoreDebuggerMcp.csproj
@@ -30,6 +30,7 @@
   <ItemGroup>
     <None Include="../../README.md" Pack="true" PackagePath="" />
     <None Include="icon.png" Pack="true" PackagePath="" />
+    <None Include="runtimes/**/*" Pack="true" PackagePath="tools/net10.0/any/runtimes/" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AspNetCoreDebuggerMcp/Debugging/NetcoredbgLocator.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/NetcoredbgLocator.cs
@@ -1,44 +1,70 @@
+using System.Runtime.InteropServices;
+
 namespace AspNetCoreDebuggerMcp.Debugging;
 
 /// Finds the netcoredbg executable on disk.
-/// Resolution order: NETCOREDBG_PATH env var → bundled-next-to-assembly → on PATH.
+/// Resolution order:
+///   1. NETCOREDBG_PATH env var
+///   2. Bundled binary at runtimes/&lt;rid&gt;/native/netcoredbg[.exe]
+///   3. On PATH
 internal static class NetcoredbgLocator
 {
     public const string EnvironmentVariable = "NETCOREDBG_PATH";
 
-    public static string Locate()
+    public static string Locate() =>
+        LocateCore(
+            envPath: Environment.GetEnvironmentVariable(EnvironmentVariable),
+            baseDirectory: AppContext.BaseDirectory,
+            rid: CurrentRid(),
+            isWindows: RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            pathEnv: Environment.GetEnvironmentVariable("PATH") ?? "",
+            fileExists: File.Exists);
+
+    internal static string LocateCore(
+        string? envPath,
+        string baseDirectory,
+        string rid,
+        bool isWindows,
+        string pathEnv,
+        Func<string, bool> fileExists)
     {
-        var envPath = Environment.GetEnvironmentVariable(EnvironmentVariable);
-        if (!string.IsNullOrWhiteSpace(envPath) && File.Exists(envPath))
+        if (!string.IsNullOrWhiteSpace(envPath) && fileExists(envPath))
             return envPath;
 
-        var baseDir = AppContext.BaseDirectory;
-        foreach (var candidate in new[]
-        {
-            Path.Combine(baseDir, "netcoredbg", "netcoredbg"),
-            Path.Combine(baseDir, "netcoredbg"),
-        })
-        {
-            if (File.Exists(candidate)) return candidate;
-        }
+        var exe = isWindows ? "netcoredbg.exe" : "netcoredbg";
+        var bundled = Path.Combine(baseDirectory, "runtimes", rid, "native", exe);
+        if (fileExists(bundled))
+            return bundled;
 
-        var onPath = FindOnPath("netcoredbg");
-        if (onPath is not null) return onPath;
-
-        throw new FileNotFoundException(
-            $"netcoredbg executable not found. Set the {EnvironmentVariable} environment variable " +
-            "to the netcoredbg binary, or place it on PATH.");
-    }
-
-    private static string? FindOnPath(string name)
-    {
-        var path = Environment.GetEnvironmentVariable("PATH") ?? "";
-        foreach (var dir in path.Split(Path.PathSeparator))
+        foreach (var dir in pathEnv.Split(Path.PathSeparator))
         {
             if (string.IsNullOrWhiteSpace(dir)) continue;
-            var full = Path.Combine(dir, name);
-            if (File.Exists(full)) return full;
+            var candidate = Path.Combine(dir, exe);
+            if (fileExists(candidate)) return candidate;
         }
-        return null;
+
+        throw new FileNotFoundException(
+            $"netcoredbg executable not found. The package should bundle a binary for RID '{rid}' " +
+            $"at runtimes/{rid}/native/{exe}. Set the {EnvironmentVariable} environment variable to " +
+            "override, or install netcoredbg on PATH.");
+    }
+
+    internal static string CurrentRid()
+    {
+        var os = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "win"
+               : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "osx"
+               : RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "linux"
+               : throw new PlatformNotSupportedException(
+                   $"Unsupported OS: {RuntimeInformation.OSDescription}");
+
+        var arch = RuntimeInformation.ProcessArchitecture switch
+        {
+            Architecture.X64 => "x64",
+            Architecture.Arm64 => "arm64",
+            var a => throw new PlatformNotSupportedException(
+                $"Unsupported process architecture: {a}"),
+        };
+
+        return $"{os}-{arch}";
     }
 }

--- a/tests/AspNetCoreDebuggerMcp.Tests/AspNetCoreDebuggerMcp.Tests.csproj
+++ b/tests/AspNetCoreDebuggerMcp.Tests/AspNetCoreDebuggerMcp.Tests.csproj
@@ -20,6 +20,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\AspNetCoreDebuggerMcp\AspNetCoreDebuggerMcp.csproj" />
+    <!-- Build SampleWebApi for the integration test (E2E debug session). Don't link its
+         output assembly into the test process — we only need its DLL on disk. -->
+    <ProjectReference Include="..\fixtures\SampleWebApi\SampleWebApi.csproj">
+      <Private>false</Private>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>

--- a/tests/AspNetCoreDebuggerMcp.Tests/Debugging/NetcoredbgLocatorTests.cs
+++ b/tests/AspNetCoreDebuggerMcp.Tests/Debugging/NetcoredbgLocatorTests.cs
@@ -1,0 +1,101 @@
+using AspNetCoreDebuggerMcp.Debugging;
+
+namespace AspNetCoreDebuggerMcp.Tests.Debugging;
+
+public class NetcoredbgLocatorTests
+{
+    [Fact]
+    public void EnvVar_Wins_WhenSetAndFileExists()
+    {
+        var result = NetcoredbgLocator.LocateCore(
+            envPath: "/custom/netcoredbg",
+            baseDirectory: "/tool",
+            rid: "osx-arm64",
+            isWindows: false,
+            pathEnv: "/usr/bin",
+            fileExists: p => p == "/custom/netcoredbg" || p == "/tool/runtimes/osx-arm64/native/netcoredbg");
+
+        Assert.Equal("/custom/netcoredbg", result);
+    }
+
+    [Fact]
+    public void EnvVar_Ignored_WhenFileMissing()
+    {
+        var result = NetcoredbgLocator.LocateCore(
+            envPath: "/nope/netcoredbg",
+            baseDirectory: "/tool",
+            rid: "osx-arm64",
+            isWindows: false,
+            pathEnv: "",
+            fileExists: p => p == "/tool/runtimes/osx-arm64/native/netcoredbg");
+
+        Assert.Equal("/tool/runtimes/osx-arm64/native/netcoredbg", result);
+    }
+
+    [Fact]
+    public void BundledBinary_ResolvedFromRid()
+    {
+        var result = NetcoredbgLocator.LocateCore(
+            envPath: null,
+            baseDirectory: "/tool",
+            rid: "linux-x64",
+            isWindows: false,
+            pathEnv: "",
+            fileExists: p => p == "/tool/runtimes/linux-x64/native/netcoredbg");
+
+        Assert.Equal("/tool/runtimes/linux-x64/native/netcoredbg", result);
+    }
+
+    [Fact]
+    public void BundledBinary_UsesExeOnWindows()
+    {
+        var expected = Path.Combine(@"C:\tool", "runtimes", "win-x64", "native", "netcoredbg.exe");
+
+        var result = NetcoredbgLocator.LocateCore(
+            envPath: null,
+            baseDirectory: @"C:\tool",
+            rid: "win-x64",
+            isWindows: true,
+            pathEnv: "",
+            fileExists: p => p == expected);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void FallsBack_ToPath_WhenBundledMissing()
+    {
+        var result = NetcoredbgLocator.LocateCore(
+            envPath: null,
+            baseDirectory: "/tool",
+            rid: "osx-arm64",
+            isWindows: false,
+            pathEnv: "/usr/local/bin:/usr/bin",
+            fileExists: p => p == "/usr/local/bin/netcoredbg");
+
+        Assert.Equal("/usr/local/bin/netcoredbg", result);
+    }
+
+    [Fact]
+    public void Throws_WhenNothingFound()
+    {
+        var ex = Assert.Throws<FileNotFoundException>(() =>
+            NetcoredbgLocator.LocateCore(
+                envPath: null,
+                baseDirectory: "/tool",
+                rid: "osx-arm64",
+                isWindows: false,
+                pathEnv: "/usr/bin",
+                fileExists: _ => false));
+
+        Assert.Contains("osx-arm64", ex.Message);
+        Assert.Contains(NetcoredbgLocator.EnvironmentVariable, ex.Message);
+    }
+
+    [Fact]
+    public void CurrentRid_ReturnsOsAndArch()
+    {
+        var rid = NetcoredbgLocator.CurrentRid();
+        Assert.Matches(@"^(win|osx|linux)-(x64|arm64)$", rid);
+    }
+}

--- a/tests/AspNetCoreDebuggerMcp.Tests/Integration/BundledNetcoredbgEndToEndTests.cs
+++ b/tests/AspNetCoreDebuggerMcp.Tests/Integration/BundledNetcoredbgEndToEndTests.cs
@@ -1,0 +1,168 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using AspNetCoreDebuggerMcp.Debugging;
+
+namespace AspNetCoreDebuggerMcp.Tests.Integration;
+
+/// End-to-end test exercising the same production code path the MCP tools use
+/// (DebugSession.LaunchAsync → AddLineBreakpoint → WaitForStop → Continue) against
+/// a real ASP.NET Core Web API target debugged through the *bundled* netcoredbg.
+///
+/// Skips when bundled binaries haven't been staged via scripts/fetch-netcoredbg-binaries.sh.
+[Trait("Category", "Integration")]
+public class BundledNetcoredbgEndToEndTests
+{
+    [Fact]
+    public async Task DebugSession_LaunchesWebApi_HitsBreakpointOnRequest()
+    {
+        var bundled = LocateBundledNetcoredbg();
+        if (bundled is null)
+        {
+            // No bundled binary for this RID — most likely CI host without the fetch
+            // step, or local dev who hasn't run scripts/fetch-netcoredbg-binaries.sh.
+            // Skip rather than fail.
+            return;
+        }
+
+        var webApiDll = LocateBuiltAssembly("SampleWebApi");
+        var programCs = LocateSourceFile("SampleWebApi", "Program.cs");
+        var port = GetFreeTcpPort();
+        var baseUrl = $"http://127.0.0.1:{port}";
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+        await using var session = await DebugSession.LaunchAsync(
+            netcoredbgPath: bundled,
+            program: webApiDll,
+            args: new[] { "--urls", baseUrl },
+            cwd: Path.GetDirectoryName(webApiDll),
+            stopAtEntry: false,
+            cts.Token);
+
+        // Line 6 of Program.cs is inside the GET /users handler lambda body
+        // (`var name = $"User{id}";`). Hit only when a request arrives.
+        const int handlerLine = 6;
+        await session.AddLineBreakpointAsync(
+            sourcePath: programCs, line: handlerLine,
+            condition: null, hitCondition: null, logMessage: null, cts.Token);
+
+        await WaitForWebApiReadyAsync(baseUrl, cts.Token);
+
+        // Fire the request that should hit the breakpoint. Don't await — the
+        // request will hang while netcoredbg holds the debuggee paused at the BP.
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+        var requestTask = http.GetAsync($"{baseUrl}/users/42", cts.Token);
+
+        var stop = await session.WaitForStopAsync(TimeSpan.FromSeconds(20), cts.Token);
+        Assert.NotNull(stop);
+        Assert.Equal("breakpoint", stop.Reason);
+        Assert.NotNull(stop.ThreadId);
+
+        // Resume the debuggee so the request can complete.
+        await session.ContinueAsync(stop.ThreadId, cts.Token);
+        var response = await requestTask;
+        Assert.True(response.IsSuccessStatusCode,
+            $"Expected 2xx, got {(int)response.StatusCode}: {response.ReasonPhrase}");
+
+        await session.DisconnectAsync(cts.Token);
+    }
+
+    // ---- helpers ------------------------------------------------------------
+
+    /// Walks up from the test bin dir to find a bundled netcoredbg matching the
+    /// current host RID. Returns null when not staged.
+    private static string? LocateBundledNetcoredbg()
+    {
+        var rid = NetcoredbgLocator.CurrentRid();
+        var exe = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? "netcoredbg.exe" : "netcoredbg";
+
+        var repoRoot = FindRepoRoot();
+        if (repoRoot is null) return null;
+
+        var srcBin = Path.Combine(repoRoot, "src", "AspNetCoreDebuggerMcp", "bin");
+        if (!Directory.Exists(srcBin)) return null;
+
+        foreach (var configDir in Directory.EnumerateDirectories(srcBin))
+        foreach (var tfmDir in Directory.EnumerateDirectories(configDir))
+        {
+            var candidate = Path.Combine(tfmDir, "runtimes", rid, "native", exe);
+            if (File.Exists(candidate)) return candidate;
+        }
+        return null;
+    }
+
+    private static string LocateBuiltAssembly(string projectName)
+    {
+        var repoRoot = FindRepoRoot()
+            ?? throw new InvalidOperationException("Repo root not found from test bin dir");
+        var fixtureBin = Path.Combine(repoRoot, "tests", "fixtures", projectName, "bin");
+        if (!Directory.Exists(fixtureBin))
+            throw new FileNotFoundException(
+                $"{projectName} not built. Expected at {fixtureBin}");
+
+        foreach (var configDir in Directory.EnumerateDirectories(fixtureBin))
+        foreach (var tfmDir in Directory.EnumerateDirectories(configDir))
+        {
+            var dll = Path.Combine(tfmDir, $"{projectName}.dll");
+            if (File.Exists(dll)) return dll;
+        }
+        throw new FileNotFoundException(
+            $"{projectName}.dll not found under any config/tfm in {fixtureBin}");
+    }
+
+    private static string LocateSourceFile(string projectName, string fileName)
+    {
+        var repoRoot = FindRepoRoot()
+            ?? throw new InvalidOperationException("Repo root not found from test bin dir");
+        var path = Path.Combine(repoRoot, "tests", "fixtures", projectName, fileName);
+        if (!File.Exists(path))
+            throw new FileNotFoundException($"Expected source file at {path}");
+        return path;
+    }
+
+    private static string? FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "AspNetCoreDebuggerMcp.slnx"))
+                || File.Exists(Path.Combine(dir.FullName, "SPEC.md")))
+            {
+                return dir.FullName;
+            }
+            dir = dir.Parent;
+        }
+        return null;
+    }
+
+    private static int GetFreeTcpPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try { return ((IPEndPoint)listener.LocalEndpoint).Port; }
+        finally { listener.Stop(); }
+    }
+
+    private static async Task WaitForWebApiReadyAsync(string baseUrl, CancellationToken ct)
+    {
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(1) };
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+        while (DateTime.UtcNow < deadline)
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                var resp = await http.GetAsync($"{baseUrl}/health", ct);
+                if (resp.IsSuccessStatusCode) return;
+            }
+            catch
+            {
+                // not listening yet — retry
+            }
+            await Task.Delay(250, ct);
+        }
+        throw new TimeoutException($"Web API at {baseUrl} did not become ready in 30s");
+    }
+}

--- a/tests/fixtures/SampleWebApi/Program.cs
+++ b/tests/fixtures/SampleWebApi/Program.cs
@@ -1,0 +1,12 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/users/{id:int}", (int id) =>
+{
+    var name = $"User{id}";
+    return Results.Ok(new { id, name });
+});
+
+app.MapGet("/health", () => Results.Ok(new { status = "ok" }));
+
+app.Run();

--- a/tests/fixtures/SampleWebApi/SampleWebApi.csproj
+++ b/tests/fixtures/SampleWebApi/SampleWebApi.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Eliminates the manual `netcoredbg` install step. The NuGet package now bundles prebuilt netcoredbg binaries for five RIDs (`linux-x64`, `linux-arm64`, `win-x64`, `osx-x64`, `osx-arm64`) and auto-resolves the right one at startup. `NETCOREDBG_PATH` remains as an escape hatch for custom builds.

Install flow drops from 4 steps to 3.

## What changed

**Wave 1 — code + tests**
- `NetcoredbgLocator` rewritten with an injectable `LocateCore` so resolution is testable. Order: `NETCOREDBG_PATH` env var → bundled binary at `runtimes/<rid>/native/netcoredbg[.exe]` → PATH → throw with a clear error.
- csproj: `<None Include="runtimes/**/*" CopyToOutputDirectory="PreserveNewest" />` — `PackAsTool` then routes content into `tools/net10.0/any/runtimes/` automatically.
- SPEC.md: new "Bundled netcoredbg" section.
- 7 new unit tests covering all locator branches.

**Wave 2 — binaries**
- `scripts/fetch-netcoredbg-binaries.sh` — pulls pinned netcoredbg `3.1.3-1062` for all 5 RIDs (4 Samsung prebuilts + 1 of ours).
- `scripts/package-netcoredbg-osx-arm64.sh` — packages a locally-built arm64 binary into a Samsung-layout tarball.
- Vendor release: [`vendor-netcoredbg-3.1.3-1062`](https://github.com/magna-nz/aspnetcore-debugger-mcp/releases/tag/vendor-netcoredbg-3.1.3-1062) hosts our `osx-arm64` tarball.
- `.gitignore`: `src/AspNetCoreDebuggerMcp/runtimes/` (binaries fetched in CI, not committed).
- `release.yml` and `ci.yml`: fetch binaries before restore/build.

**Wave 3 — docs + E2E test**
- README: 4 → 3 install steps. No more manual netcoredbg prerequisite. No `NETCOREDBG_PATH` in default config.
- `docs/install.md`: rewritten with "What's bundled" line and "Using a custom netcoredbg build" escape-hatch section.
- `docs/macos-arm64.md`: reframed as "(advanced)" — only relevant for building your own.
- `docs/contributing.md` + `docs/limits.md`: aligned.
- `tests/fixtures/SampleWebApi/`: minimal ASP.NET Core 10 web API.
- `scripts/smoke-test-bundled-binary.sh`: DAP-layer smoke check.
- **`BundledNetcoredbgEndToEndTests`**: real integration test that uses `DebugSession.LaunchAsync` (the same code path the MCP tools use) to launch SampleWebApi via the bundled netcoredbg, sets a line breakpoint on the `/users` handler, fires `GET /users/42`, asserts the breakpoint hits with `reason="breakpoint"`, then continues and tears down.

## Local verification

- `dotnet test`: 87/87 passing (was 79 before this branch).
- `bash scripts/fetch-netcoredbg-binaries.sh`: 5 RIDs staged successfully.
- `bash scripts/smoke-test-bundled-binary.sh` on osx-arm64: PASS.
- `BundledNetcoredbgEndToEndTests.DebugSession_LaunchesWebApi_HitsBreakpointOnRequest`: PASS (2s).
- `dotnet pack` with binaries staged: 18 MB `.nupkg`, no warnings.

## To ship

After merge, publishing a new GitHub release (e.g. tag `v0.2.0-preview`) will trigger the release workflow, which fetches binaries, packs, attaches the `.nupkg` to the release, and pushes to NuGet.

Closes MAG-47

🤖 Generated with [Claude Code](https://claude.com/claude-code)