### PR TITLE
Add Dockerfile for Glama submission (MAG-48)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+**/bin/
+**/obj/
+**/nupkg/
+**/.vs/
+**/.vscode/
+**/.idea/
+.git/
+.github/
+.claude/
+docs/
+*.md
+!README.md
+.netcoredbg-build/
+external/netcoredbg/build/
+src/AspNetCoreDebuggerMcp/runtimes/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Multi-stage build for the aspnetcore-debugger-mcp MCP server.
+#
+# This image is what Glama.ai uses to build, start, and introspect the server.
+# At runtime the MCP server speaks JSON-RPC over stdio; Glama can attach to it
+# and call `tools/list` to enumerate the tool surface.
+#
+# Build:  docker build -t aspnetcore-debugger-mcp .
+# Run:    docker run -i --rm aspnetcore-debugger-mcp     # -i for stdin (MCP is stdio)
+
+# ---- Build stage --------------------------------------------------------------
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+# `unzip` is needed for the Samsung win-x64 archive; the SDK image doesn't include it.
+RUN apt-get update && apt-get install -y --no-install-recommends unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Fetch bundled netcoredbg binaries (linux-x64 + linux-arm64 needed at runtime
+# in-container; others ship for completeness). Cached as a separate layer from
+# the source copy so source edits don't re-trigger the ~17 MB download.
+COPY scripts/fetch-netcoredbg-binaries.sh ./scripts/
+RUN bash scripts/fetch-netcoredbg-binaries.sh
+
+COPY . .
+RUN dotnet publish src/AspNetCoreDebuggerMcp -c Release -o /app
+
+# ---- Runtime stage ------------------------------------------------------------
+# ASP.NET runtime image because netcoredbg's bundled DLLs include some
+# Microsoft.CodeAnalysis bits that resolve against the ASP.NET shared
+# framework; using `aspnet` is the safer choice over plain `runtime`.
+FROM mcr.microsoft.com/dotnet/aspnet:10.0
+WORKDIR /app
+COPY --from=build /app .
+
+# MCP servers are stdio-based — no port to expose.
+ENTRYPOINT ["dotnet", "AspNetCoreDebuggerMcp.dll"]


### PR DESCRIPTION
## Summary

Adds a `Dockerfile` so [Glama.ai](https://glama.ai/mcp/servers) can build the MCP server, start it, and run its introspection check. Required by [punkpeye/awesome-mcp-servers#6823](https://github.com/punkpeye/awesome-mcp-servers/pull/6823) — the reviewer wants a Glama score badge on listed servers.

## What's in the build

- **Stage 1** (`sdk:10.0`): install `unzip` (needed for Samsung's win-x64 zip), run `scripts/fetch-netcoredbg-binaries.sh`, `dotnet publish` to `/app`.
- **Stage 2** (`aspnet:10.0`): copy published output, `ENTRYPOINT` the tool. MCP is stdio so no port exposed.
- `.dockerignore` keeps the context lean and lets the in-build fetch own `runtimes/`.

## Local verification

```bash
docker build -t aspnetcore-debugger-mcp:test .
```

Then a stdio probe sending `initialize` → `tools/list`:

```
initialize: OK  (serverInfo={'name': 'AspNetCoreDebuggerMcp', 'version': '0.1.0.0'})
tools/list: OK  (26 tools)
```

Matches what Glama's check expects.

## After merge

1. Submit the repo to https://glama.ai/mcp/servers.
2. Wait for Glama's introspection check to pass (it picks up the Dockerfile from the repo).
3. Add the Glama score badge to PR #6823 on punkpeye/awesome-mcp-servers.

Closes MAG-48

🤖 Generated with [Claude Code](https://claude.com/claude-code)