### PR TITLE
DX polish: debugger_health tool + README trace example (MAG-49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,30 @@ with variables — without you setting any breakpoint manually.
 > the null check on line 65 only checks `cart` itself, not `cart.Items`. Two fix options:
 > initialise `Items = []` in the `Cart` constructor, or use `cart.Items ?? []` on line 67.
 
+### Trace a request through the call chain
+
+**You**
+
+> Hit `GET /order/42` and show me which methods get called and the arguments at each one — I
+> don't want to set breakpoints by hand.
+
+**Claude**
+
+> I'll instrument your order pipeline (Controller → Service → Repository → SqlClient) and fire
+> the request. The instrumentation auto-resumes after each capture, so your code runs at
+> near-normal speed.
+>
+> ```
+> [+  679ms] → OrderController.GetOrder()       id=42, data=null
+> [+  711ms] --→ OrderService.LookupOrder()     id=42, raw=null, enriched=null
+> [+  735ms] ----→ OrderRepository.FetchById()  id=42
+> [+  759ms] ------→ SqlClient.ExecuteQuery()   sql="SELECT * FROM orders WHERE id = 42"
+> [+  783ms] ----→ EnrichmentService.Enrich()   raw="rows(sql=…)"
+> ```
+>
+> Every line is one real method entry with the actual arguments at that moment. The arrows
+> show call depth. The request finished with 200 — no manual breakpoints, no pauses.
+
 [See 5 more →](docs/examples.md)
 
 ## How it works

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,9 +1,10 @@
 # What you can do with it
 
-Seven everyday scenarios. Each shows what you'd ask Claude in plain English and what Claude
+Eight everyday scenarios. Each shows what you'd ask Claude in plain English and what Claude
 might come back with. The wording is illustrative — the actual response depends on your code —
 but the **shape** of the conversation is real, and the values shown come from real runs.
 
+- [Is the debugger set up correctly?](#is-the-debugger-set-up-correctly)
 - [Why is my endpoint returning the wrong data?](#why-is-my-endpoint-returning-the-wrong-data)
 - [Try a fix without editing my code](#try-a-fix-without-editing-my-code)
 - [Why did my app throw this exception?](#why-did-my-app-throw-this-exception)
@@ -11,6 +12,30 @@ but the **shape** of the conversation is real, and the values shown come from re
 - [Where am I right now in the call stack?](#where-am-i-right-now-in-the-call-stack)
 - [Why is my app hung?](#why-is-my-app-hung)
 - [Show me what the server is logging](#show-me-what-the-server-is-logging)
+
+---
+
+## Is the debugger set up correctly?
+
+**You**
+
+> Before we start — is the debugger ready? I'm not sure if it picked up the right binary on
+> my Mac.
+
+**Claude**
+
+> I'll check.
+>
+> Yes — the bundled netcoredbg is healthy on your machine.
+>
+> - **Platform:** macOS, arm64 (RID `osx-arm64`)
+> - **Binary:** the one that shipped with the NuGet package — no `NETCOREDBG_PATH`
+>   override is set, and you're not falling back to a binary on `PATH`
+> - **Version:** `NET Core debugger 3.1.3-1 (Release)`
+>
+> You're good to launch a debug session whenever you want.
+
+<sub>*(under the hood: one call to `debugger_health` — reports RID, resolved netcoredbg path, source (bundled / env var / PATH), and `--version`)*</sub>
 
 ---
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -59,6 +59,7 @@ result that's ready to drop into a reply.
 | `trace_get` | Read the trace events captured since you started, plus a rendered timeline showing each call with `→` and depth-based indentation. |
 | `trace_stop` | Stop the trace and clear its watch points. |
 | `process_read_output` | Drain the app's stdout/stderr since the last call. Captures whatever `Console.WriteLine`, `ILogger`, or ASP.NET Core's request logging produces. |
+| `debugger_health` | Self-diagnostic. Reports your platform, RID, the resolved netcoredbg path, where it came from (bundled / env var / PATH), and the `--version` banner. Call this first if something looks off, instead of starting a real debug session to find out. |
 
 ## Notes on tool behaviour
 

--- a/src/AspNetCoreDebuggerMcp/Debugging/NetcoredbgLocator.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/NetcoredbgLocator.cs
@@ -2,6 +2,18 @@ using System.Runtime.InteropServices;
 
 namespace AspNetCoreDebuggerMcp.Debugging;
 
+/// Where a resolved netcoredbg binary came from. `debugger_health` surfaces
+/// this so an agent can distinguish "you set the env var" from "we used
+/// the bundled binary" without rerunning resolution.
+internal enum NetcoredbgSource
+{
+    EnvironmentVariable,
+    Bundled,
+    OnPath,
+}
+
+internal sealed record NetcoredbgLocation(string Path, NetcoredbgSource Source);
+
 /// Finds the netcoredbg executable on disk.
 /// Resolution order:
 ///   1. NETCOREDBG_PATH env var
@@ -11,16 +23,23 @@ internal static class NetcoredbgLocator
 {
     public const string EnvironmentVariable = "NETCOREDBG_PATH";
 
-    public static string Locate() =>
-        LocateCore(
+    public static string Locate()
+    {
+        var loc = TryLocate();
+        if (loc is null) throw NotFound(CurrentRid(), IsWindows());
+        return loc.Path;
+    }
+
+    public static NetcoredbgLocation? TryLocate() =>
+        TryLocateCore(
             envPath: Environment.GetEnvironmentVariable(EnvironmentVariable),
             baseDirectory: AppContext.BaseDirectory,
             rid: CurrentRid(),
-            isWindows: RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            isWindows: IsWindows(),
             pathEnv: Environment.GetEnvironmentVariable("PATH") ?? "",
             fileExists: File.Exists);
 
-    internal static string LocateCore(
+    internal static NetcoredbgLocation? TryLocateCore(
         string? envPath,
         string baseDirectory,
         string rid,
@@ -29,24 +48,32 @@ internal static class NetcoredbgLocator
         Func<string, bool> fileExists)
     {
         if (!string.IsNullOrWhiteSpace(envPath) && fileExists(envPath))
-            return envPath;
+            return new NetcoredbgLocation(envPath, NetcoredbgSource.EnvironmentVariable);
 
         var exe = isWindows ? "netcoredbg.exe" : "netcoredbg";
         var bundled = Path.Combine(baseDirectory, "runtimes", rid, "native", exe);
         if (fileExists(bundled))
-            return bundled;
+            return new NetcoredbgLocation(bundled, NetcoredbgSource.Bundled);
 
         foreach (var dir in pathEnv.Split(Path.PathSeparator))
         {
             if (string.IsNullOrWhiteSpace(dir)) continue;
             var candidate = Path.Combine(dir, exe);
-            if (fileExists(candidate)) return candidate;
+            if (fileExists(candidate))
+                return new NetcoredbgLocation(candidate, NetcoredbgSource.OnPath);
         }
 
-        throw new FileNotFoundException(
-            $"netcoredbg executable not found. The package should bundle a binary for RID '{rid}' " +
-            $"at runtimes/{rid}/native/{exe}. Set the {EnvironmentVariable} environment variable to " +
-            "override, or install netcoredbg on PATH.");
+        return null;
+    }
+
+    /// Path-only variant kept for the existing tests that predate `TryLocateCore`.
+    internal static string LocateCore(
+        string? envPath, string baseDirectory, string rid,
+        bool isWindows, string pathEnv, Func<string, bool> fileExists)
+    {
+        var loc = TryLocateCore(envPath, baseDirectory, rid, isWindows, pathEnv, fileExists);
+        if (loc is null) throw NotFound(rid, isWindows);
+        return loc.Path;
     }
 
     internal static string CurrentRid()
@@ -66,5 +93,16 @@ internal static class NetcoredbgLocator
         };
 
         return $"{os}-{arch}";
+    }
+
+    private static bool IsWindows() => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+    private static FileNotFoundException NotFound(string rid, bool isWindows)
+    {
+        var exe = isWindows ? "netcoredbg.exe" : "netcoredbg";
+        return new FileNotFoundException(
+            $"netcoredbg executable not found. The package should bundle a binary for RID '{rid}' " +
+            $"at runtimes/{rid}/native/{exe}. Set the {EnvironmentVariable} environment variable to " +
+            "override, or install netcoredbg on PATH.");
     }
 }

--- a/src/AspNetCoreDebuggerMcp/Tools/HealthTools.cs
+++ b/src/AspNetCoreDebuggerMcp/Tools/HealthTools.cs
@@ -1,0 +1,110 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using AspNetCoreDebuggerMcp.Debugging;
+using ModelContextProtocol.Server;
+using static AspNetCoreDebuggerMcp.Tools.ToolResults;
+
+namespace AspNetCoreDebuggerMcp.Tools;
+
+[McpServerToolType]
+public sealed class HealthTools
+{
+    [McpServerTool(Name = "debugger_health")]
+    [Description("Self-diagnostic. Reports the host platform, RID, resolved netcoredbg path " +
+        "(or that it's missing), where the binary came from (bundled / env var / PATH), and the " +
+        "netcoredbg version it reports. Call this first when something looks wrong, instead of " +
+        "starting a real debug session to find out.")]
+    public Task<string> DebuggerHealthAsync(CancellationToken ct = default)
+    {
+        var rid = NetcoredbgLocator.CurrentRid();
+        var loc = NetcoredbgLocator.TryLocate();
+
+        var os = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "windows"
+               : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "macos"
+               : RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "linux"
+               : "unknown";
+        var arch = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
+        var envVarValue = Environment.GetEnvironmentVariable(NetcoredbgLocator.EnvironmentVariable);
+
+        if (loc is null)
+        {
+            var report = new
+            {
+                status = "binaryNotFound",
+                rid,
+                platform = new { os, architecture = arch },
+                envVar = new
+                {
+                    name = NetcoredbgLocator.EnvironmentVariable,
+                    set = !string.IsNullOrWhiteSpace(envVarValue),
+                    value = envVarValue,
+                },
+                hint = $"No netcoredbg bundled for RID '{rid}' and none on PATH. Set " +
+                       $"{NetcoredbgLocator.EnvironmentVariable} to a binary you've built or downloaded.",
+            };
+            return Task.FromResult(Serialize(report));
+        }
+
+        var version = TryReadVersion(loc.Path, ct);
+
+        var ok = new
+        {
+            status = "ok",
+            rid,
+            platform = new { os, architecture = arch },
+            netcoredbg = new
+            {
+                path = loc.Path,
+                source = loc.Source.ToString(),  // EnvironmentVariable | Bundled | OnPath
+                version,                           // null if --version couldn't be read
+            },
+            envVar = new
+            {
+                name = NetcoredbgLocator.EnvironmentVariable,
+                set = !string.IsNullOrWhiteSpace(envVarValue),
+                value = envVarValue,
+            },
+        };
+        return Task.FromResult(Serialize(ok));
+    }
+
+    private static string? TryReadVersion(string netcoredbgPath, CancellationToken ct)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = netcoredbgPath,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            psi.ArgumentList.Add("--version");
+
+            using var proc = Process.Start(psi);
+            if (proc is null) return null;
+
+            // Bound the wait so a hung binary doesn't hang the tool call.
+            if (!proc.WaitForExit(2_000))
+            {
+                try { proc.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+                return null;
+            }
+
+            var stdout = proc.StandardOutput.ReadToEnd();
+            // First non-empty line is the version banner (e.g. "NET Core debugger 3.1.3-1 (...)").
+            foreach (var line in stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var trimmed = line.TrimEnd('\r').Trim();
+                if (trimmed.Length > 0) return trimmed;
+            }
+            return null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/tests/AspNetCoreDebuggerMcp.Tests/Debugging/NetcoredbgLocatorTests.cs
+++ b/tests/AspNetCoreDebuggerMcp.Tests/Debugging/NetcoredbgLocatorTests.cs
@@ -98,4 +98,67 @@ public class NetcoredbgLocatorTests
         var rid = NetcoredbgLocator.CurrentRid();
         Assert.Matches(@"^(win|osx|linux)-(x64|arm64)$", rid);
     }
+
+    // ---- TryLocateCore: returns source identifier for diagnostics --------------
+
+    [Fact]
+    public void TryLocateCore_EnvVar_ReportsEnvironmentVariableSource()
+    {
+        var result = NetcoredbgLocator.TryLocateCore(
+            envPath: "/custom/netcoredbg",
+            baseDirectory: "/tool",
+            rid: "osx-arm64",
+            isWindows: false,
+            pathEnv: "/usr/bin",
+            fileExists: p => p == "/custom/netcoredbg");
+
+        Assert.NotNull(result);
+        Assert.Equal(NetcoredbgSource.EnvironmentVariable, result.Source);
+        Assert.Equal("/custom/netcoredbg", result.Path);
+    }
+
+    [Fact]
+    public void TryLocateCore_Bundled_ReportsBundledSource()
+    {
+        var result = NetcoredbgLocator.TryLocateCore(
+            envPath: null,
+            baseDirectory: "/tool",
+            rid: "linux-x64",
+            isWindows: false,
+            pathEnv: "",
+            fileExists: p => p == "/tool/runtimes/linux-x64/native/netcoredbg");
+
+        Assert.NotNull(result);
+        Assert.Equal(NetcoredbgSource.Bundled, result.Source);
+    }
+
+    [Fact]
+    public void TryLocateCore_OnPath_ReportsOnPathSource()
+    {
+        var result = NetcoredbgLocator.TryLocateCore(
+            envPath: null,
+            baseDirectory: "/tool",
+            rid: "osx-arm64",
+            isWindows: false,
+            pathEnv: "/usr/local/bin:/usr/bin",
+            fileExists: p => p == "/usr/local/bin/netcoredbg");
+
+        Assert.NotNull(result);
+        Assert.Equal(NetcoredbgSource.OnPath, result.Source);
+        Assert.Equal("/usr/local/bin/netcoredbg", result.Path);
+    }
+
+    [Fact]
+    public void TryLocateCore_ReturnsNull_WhenNothingFound()
+    {
+        var result = NetcoredbgLocator.TryLocateCore(
+            envPath: null,
+            baseDirectory: "/tool",
+            rid: "osx-arm64",
+            isWindows: false,
+            pathEnv: "/usr/bin",
+            fileExists: _ => false);
+
+        Assert.Null(result);
+    }
 }


### PR DESCRIPTION
## Summary

Two small DX improvements:

1. **`debugger_health` MCP tool** — a self-diagnostic the agent can call to check the debugger is ready, instead of starting a real session to find out.
2. **README hero — third worked example using `trace_start`** — surfaces the server-side request tracing differentiator on the landing page (was only in `docs/examples.md` before).

## What changed

**Locator refactor (non-breaking)**
- `NetcoredbgLocator`: new `TryLocate()` / `TryLocateCore()` returning a `NetcoredbgLocation(Path, Source)`. The `NetcoredbgSource` enum reports whether the resolved binary came from the env var, the bundle, or PATH. The existing `Locate()` / `LocateCore()` signatures (used by `DebugSessionManager`) are preserved with their throw-on-miss semantics.
- 4 new branch tests for `TryLocateCore`.

**New tool**
- `Tools/HealthTools.cs` — single tool `debugger_health`. Returns:
  ```json
  {
    "status": "ok" | "binaryNotFound",
    "rid": "osx-arm64",
    "platform": {"os": "macos", "architecture": "arm64"},
    "netcoredbg": {
      "path": "...",
      "source": "Bundled" | "EnvironmentVariable" | "OnPath",
      "version": "NET Core debugger 3.1.3-1 (...)"
    },
    "envVar": {"name": "NETCOREDBG_PATH", "set": false, "value": null}
  }
  ```
- `--version` probe is bounded by a 2s timeout so a wedged binary doesn't hang the call.

**Docs**
- README: third "See it in action" example using `trace_start` on `GET /order/42`.
- `docs/examples.md`: new "Is the debugger set up correctly?" section at the top (8 examples now, was 7).
- `docs/tools.md`: row for `debugger_health` in the diagnosing-problems table.

## Verification

- 91/91 tests pass (was 87 + 4 new locator tests). Build clean.
- `debugger_health` follows the same `[McpServerToolType]` registration pattern as the other tool files; `.WithToolsFromAssembly()` picks it up automatically.

Closes MAG-49

🤖 Generated with [Claude Code](https://claude.com/claude-code)