### PR TITLE
Publish to official MCP registry + automate in release.yml (MAG-51)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write   # required to upload the .nupkg as a release asset
+    outputs:
+      version: ${{ steps.ver.outputs.version }}
 
     steps:
       - uses: actions/checkout@v4
@@ -95,3 +97,69 @@ jobs:
             --api-key "$NUGET_API_KEY" \
             --source https://api.nuget.org/v3/index.json \
             --skip-duplicate
+
+  publish-mcp-registry:
+    # Publishes .mcp/server.json to the Official MCP Registry after the NuGet
+    # package is live on nuget.org. The registry verifies the package's README
+    # contains `<!-- mcp-name: <name from server.json> -->`, so it can only run
+    # once the package is published and available.
+    needs: publish
+    # Mirror the same gate the NuGet push uses — no point publishing a manifest
+    # that points at a NuGet version that was never pushed.
+    if: |
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.push_to_nuget == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # mcp-publisher uses GitHub OIDC to prove the workflow owns io.github.magna-nz/*
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set server.json version from release tag
+        env:
+          VERSION: ${{ needs.publish.outputs.version }}
+        run: |
+          set -euo pipefail
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' \
+            .mcp/server.json > .mcp/server.json.tmp
+          mv .mcp/server.json.tmp .mcp/server.json
+          echo "--- server.json after version rewrite ---"
+          cat .mcp/server.json
+
+      - name: Wait for NuGet package to be live
+        env:
+          VERSION: ${{ needs.publish.outputs.version }}
+        run: |
+          set -euo pipefail
+          pkg_id_lower=$(jq -r '.packages[0].identifier' .mcp/server.json | tr '[:upper:]' '[:lower:]')
+          ver_lower=$(echo "$VERSION" | tr '[:upper:]' '[:lower:]')
+          url="https://api.nuget.org/v3-flatcontainer/${pkg_id_lower}/${ver_lower}/readme"
+          # NuGet validation typically completes in 5–30 minutes — poll for up to 30.
+          deadline=$(( $(date +%s) + 1800 ))
+          attempt=0
+          until curl -sfI "$url" >/dev/null; do
+            attempt=$((attempt + 1))
+            if [ "$(date +%s)" -gt "$deadline" ]; then
+              echo "::error::NuGet package $VERSION not available after 30 minutes at $url"
+              exit 1
+            fi
+            echo "[attempt $attempt] not available yet, sleeping 20s..."
+            sleep 20
+          done
+          echo "Package $VERSION is live on nuget.org."
+
+      - name: Download mcp-publisher
+        run: |
+          set -euo pipefail
+          curl -sSL -o mcp-publisher.tar.gz \
+            https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz
+          tar -xzf mcp-publisher.tar.gz
+          ./mcp-publisher --help | head -5
+
+      - name: Authenticate via GitHub OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to Official MCP Registry
+        run: ./mcp-publisher publish .mcp/server.json

--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.magna-nz/aspnetcore-debugger-mcp",
+  "version": "0.1.5-preview",
+  "title": "ASP.NET Core Debugger — MCP Server for AI Agents",
+  "description": "MCP server giving AI agents interactive .NET / ASP.NET Core debugging via netcoredbg + DAP.",
+  "websiteUrl": "https://github.com/magna-nz/aspnetcore-debugger-mcp",
+  "repository": {
+    "url": "https://github.com/magna-nz/aspnetcore-debugger-mcp",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "nuget",
+      "registryBaseUrl": "https://api.nuget.org/v3/index.json",
+      "identifier": "AspNetCoreDebuggerMcp",
+      "version": "0.1.5-preview",
+      "runtimeHint": "dnx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ASP.NET Core Debugging MCP Server
 
+<!-- mcp-name: io.github.magna-nz/aspnetcore-debugger-mcp -->
+
 [![CI](https://github.com/magna-nz/aspnetcore-debugger-mcp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/magna-nz/aspnetcore-debugger-mcp/actions/workflows/ci.yml)
 [![NuGet](https://img.shields.io/nuget/vpre/AspNetCoreDebuggerMcp.svg?label=NuGet)](https://www.nuget.org/packages/AspNetCoreDebuggerMcp)
 [![.NET](https://img.shields.io/badge/.NET-10-512BD4)](https://dotnet.microsoft.com/)


### PR DESCRIPTION
## Summary

- Adds `.mcp/server.json` describing this server for the [Official MCP Registry](https://registry.modelcontextprotocol.io) under `io.github.magna-nz/aspnetcore-debugger-mcp`
- Adds the verifying `<!-- mcp-name: ... -->` HTML comment to `README.md` (already packed into the NuGet)
- Adds a `publish-mcp-registry` job to `release.yml` that runs after the NuGet push — rewrites server.json's version from the release tag, waits for the package to go live on nuget.org, then publishes the manifest via GitHub OIDC (no PAT needed)

The Official MCP Registry is the upstream source — `github.com/mcp` pulls from it automatically per the [Microsoft Learn .NET quickstart](https://learn.microsoft.com/en-us/dotnet/ai/quickstarts/publish-mcp-registry).

## Design notes

- **Auth: GitHub OIDC over PAT.** Short-lived, no secret to rotate, namespace `io.github.magna-nz/*` unlocked automatically because the workflow runs in `magna-nz/aspnetcore-debugger-mcp`. `id-token: write` permission scoped to the publish-mcp-registry job only — the existing publish job retains only `contents: write`.
- **Version handling: CI rewrites server.json from the release tag.** Server.json in the repo carries a sentinel/last-released version (`0.1.5-preview`); CI overwrites both `version` and `packages[0].version` from `github.event.release.tag_name` before publishing. Same model as the existing csproj `<Version>` → `/p:Version=$tag` pattern.
- **Gate matches NuGet push step exactly** — no point publishing a manifest pointing at a NuGet version that was never pushed. Workflow_dispatch dry runs without `push_to_nuget=true` skip both.
- **Wait-for-NuGet uses the same flat-container README endpoint the Microsoft Learn PowerShell example uses.** 30-min timeout (matches STATUS.md's note about NuGet validation taking 5–30 min). Polls every 20s.

## What's out of scope

- **Kong MCP Registry** — Tech Preview, enterprise/Konnect only; no public submit path
- **Opening an issue on `github.com/mcp`** — they pull from the official registry now

## Test plan

- [x] `mcp-publisher validate .mcp/server.json` → clean against current `2025-12-11` schema
- [x] `actionlint` (via docker) → clean on the updated release.yml
- [ ] CI on this PR passes (build + tests still green — only docs + workflow changed)
- [ ] After merge: create release `v0.1.5-preview` → workflow fires
- [ ] `publish` job: NuGet `AspNetCoreDebuggerMcp@0.1.5-preview` shows up on nuget.org
- [ ] `publish-mcp-registry` job: listing appears at `registry.modelcontextprotocol.io` under `io.github.magna-nz/aspnetcore-debugger-mcp`

Closes MAG-51

🤖 Generated with [Claude Code](https://claude.com/claude-code)