### PR TITLE
Add Glama AI MCP server card to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 [![Platforms](https://img.shields.io/badge/runs%20on-Linux%20%7C%20macOS%20%7C%20Windows-success)](#platforms)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
+<a href="https://glama.ai/mcp/servers/magna-nz/aspnetcore-debugger-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/magna-nz/aspnetcore-debugger-mcp/badge" alt="aspnetcore-debugger-mcp MCP server" />
+</a>
+
 > **MIT-licensed [MCP](https://modelcontextprotocol.io/) server that lets an AI agent (Claude, etc.) debug your .NET / ASP.NET Core app interactively.**
 >
 > ✅ **Linux** (x64, arm64) &nbsp;·&nbsp; ✅ **macOS** (Intel + Apple Silicon) &nbsp;·&nbsp; ✅ **Windows** (x64)


### PR DESCRIPTION
## Summary
- Project is now listed on [glama.ai](https://glama.ai/mcp/servers/magna-nz/aspnetcore-debugger-mcp) following MAG-48 (Dockerfile) work and a fresh Glama build.
- Embeds the Glama card under the shields.io badge row; renders license grade (A — MIT detected), quality grade, maintenance grade, and platform icons.
- Sized to 380×200 via inline HTML so it doesn't dominate the README header.

## Test plan
- [ ] Render README on the PR page and confirm the card displays correctly
- [ ] Confirm the card renders on NuGet (README is packed into the .nupkg)
- [ ] Click through the card → lands on the Glama listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)