### PR TITLE
Shrink Glama badge to inline shields-style chip

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,7 @@
 [![MCP](https://img.shields.io/badge/MCP-compatible-005FBA)](https://modelcontextprotocol.io/)
 [![Platforms](https://img.shields.io/badge/runs%20on-Linux%20%7C%20macOS%20%7C%20Windows-success)](#platforms)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-
-<a href="https://glama.ai/mcp/servers/magna-nz/aspnetcore-debugger-mcp">
-  <img width="380" height="200" src="https://glama.ai/mcp/servers/magna-nz/aspnetcore-debugger-mcp/badge" alt="aspnetcore-debugger-mcp MCP server" />
-</a>
+[![Glama Quality](https://glama.ai/mcp/servers/magna-nz/aspnetcore-debugger-mcp/badges/score.svg)](https://glama.ai/mcp/servers/magna-nz/aspnetcore-debugger-mcp)
 
 > **MIT-licensed [MCP](https://modelcontextprotocol.io/) server that lets an AI agent (Claude, etc.) debug your .NET / ASP.NET Core app interactively.**
 >


### PR DESCRIPTION
## Summary
- The 380×200 Glama card we added in #22 was visually heavy in the README header.
- Swap for the shields.io-style `score.svg` (110×20) so it slots into the badge row next to CI / NuGet / .NET / MCP / Platforms / License.

## Test plan
- [ ] Render README on the PR page and confirm the badge sits inline with the others
- [ ] Click the badge → lands on the Glama listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)