### PR TITLE
Add glama.json with maintainers metadata

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["magna-nz"]
+}


### PR DESCRIPTION
## Summary
- Adds minimal `glama.json` at the repo root: `{"maintainers": ["magna-nz"]}`.
- Clears the "no glama.json" signal on the Glama listing.
- Schema (`https://glama.ai/mcp/schemas/server.json`) currently only requires the `maintainers` array — GitHub usernames with permission to maintain the server entry.

## Test plan
- [ ] Merge and confirm the "no glama.json" item disappears from the Glama metadata signals on next scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)