### PR TITLE
Fix Glama badge rendering — bust camo cache with ?v=2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![MCP](https://img.shields.io/badge/MCP-compatible-005FBA)](https://modelcontextprotocol.io/)
 [![Platforms](https://img.shields.io/badge/runs%20on-Linux%20%7C%20macOS%20%7C%20Windows-success)](#platforms)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Glama Quality](https://glama.ai/mcp/servers/magna-nz/aspnetcore-debugger-mcp/badges/score.svg)](https://glama.ai/mcp/servers/magna-nz/aspnetcore-debugger-mcp)
+[![Glama Quality](https://glama.ai/mcp/servers/magna-nz/aspnetcore-debugger-mcp/badges/score.svg?v=2)](https://glama.ai/mcp/servers/magna-nz/aspnetcore-debugger-mcp)
 
 > **MIT-licensed [MCP](https://modelcontextprotocol.io/) server that lets an AI agent (Claude, etc.) debug your .NET / ASP.NET Core app interactively.**
 >


### PR DESCRIPTION
## Summary

GitHub's image proxy (`camo.githubusercontent.com`) was returning `HTTP 400 Non-Image content-type returned` for our Glama badge, so the badge wasn't rendering in the README.

Root cause: camo caches both successes and rejections, keyed on a hash of the full URL. The first time camo tried to proxy our Glama badge URL, glama.ai apparently returned non-image content (likely a transient blip — possibly a 302 or HTML error page). Camo cached that rejection.

Verified that `glama.ai/mcp/servers/magna-nz/aspnetcore-debugger-mcp/badges/score.svg` now serves valid `image/svg+xml` cleanly — but camo never re-checks until the URL changes.

Fix: bump the badge URL with `?v=2`. Glama ignores the query string and serves the same valid SVG; camo treats it as a brand-new URL (different hash → new camo URL → fresh fetch).

## Test plan
- [ ] Merge and confirm the Glama badge renders in the README on github.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)