### PR TITLE
Add NuGet downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![CI](https://github.com/magna-nz/aspnetcore-debugger-mcp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/magna-nz/aspnetcore-debugger-mcp/actions/workflows/ci.yml)
 [![NuGet](https://img.shields.io/nuget/vpre/AspNetCoreDebuggerMcp.svg?label=NuGet)](https://www.nuget.org/packages/AspNetCoreDebuggerMcp)
+[![Downloads](https://img.shields.io/nuget/dt/AspNetCoreDebuggerMcp.svg?label=downloads)](https://www.nuget.org/packages/AspNetCoreDebuggerMcp)
 [![.NET](https://img.shields.io/badge/.NET-10-512BD4)](https://dotnet.microsoft.com/)
 [![MCP](https://img.shields.io/badge/MCP-compatible-005FBA)](https://modelcontextprotocol.io/)
 [![Platforms](https://img.shields.io/badge/runs%20on-Linux%20%7C%20macOS%20%7C%20Windows-success)](#platforms)


### PR DESCRIPTION
## Summary
- Adds a `shields.io/nuget/dt` downloads badge next to the version badge, linking to the package page (~290 total downloads at time of writing).
- This was supposed to land in #27 but the commit raced the merge — main got the intro/ToC changes but not the badge.

## Test plan
- [ ] Render README on the PR page — confirm the downloads badge renders with a number

🤖 Generated with [Claude Code](https://claude.com/claude-code)