### PR TITLE
Bound DebugSession output + trace buffers to fix runaway memory leak (MAG-54)

### DIFF
--- a/src/AspNetCoreDebuggerMcp/Debugging/BoundedOutputBuffer.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/BoundedOutputBuffer.cs
@@ -1,0 +1,84 @@
+using AspNetCoreDebuggerMcp.Diagnostics;
+
+namespace AspNetCoreDebuggerMcp.Debugging;
+
+/// Drop-oldest queue of DAP output lines, capped on both line count and total byte size.
+/// Whichever cap is hit first triggers eviction. The byte cap exists so a single rare-but-
+/// huge line (e.g. a multi-MB stack trace dump) can't fill memory on its own.
+///
+/// Memory safety motivation: see MAG-54 — debuggees in a hot Console.WriteLine path or an
+/// exception-logging loop can emit hundreds of MB/s of output. Without a cap, the buffer
+/// grew to ~38 GB in a few minutes during manual debugging.
+internal sealed class BoundedOutputBuffer
+{
+    public const int DefaultMaxLines = 50_000;
+    public const long DefaultMaxBytes = 64L * 1024 * 1024; // 64 MB
+
+    private readonly object _gate = new();
+    private readonly Queue<OutputLine> _items = new();
+    private readonly int _maxLines;
+    private readonly long _maxBytes;
+    private long _currentBytes;
+    private long _droppedLines;
+
+    public BoundedOutputBuffer(int maxLines = DefaultMaxLines, long maxBytes = DefaultMaxBytes)
+    {
+        if (maxLines <= 0) throw new ArgumentOutOfRangeException(nameof(maxLines));
+        if (maxBytes <= 0) throw new ArgumentOutOfRangeException(nameof(maxBytes));
+        _maxLines = maxLines;
+        _maxBytes = maxBytes;
+    }
+
+    public void Enqueue(OutputLine line)
+    {
+        var size = EstimateSize(line);
+        lock (_gate)
+        {
+            _items.Enqueue(line);
+            _currentBytes += size;
+
+            while (_items.Count > 0 && (_items.Count > _maxLines || _currentBytes > _maxBytes))
+            {
+                var dropped = _items.Dequeue();
+                _currentBytes -= EstimateSize(dropped);
+                _droppedLines++;
+            }
+        }
+    }
+
+    public IReadOnlyList<OutputLine> Drain(string? category = null, int? maxLines = null)
+    {
+        var collected = new List<OutputLine>();
+        lock (_gate)
+        {
+            while (_items.Count > 0)
+            {
+                var line = _items.Dequeue();
+                _currentBytes -= EstimateSize(line);
+                if (category is null || string.Equals(line.Category, category, StringComparison.OrdinalIgnoreCase))
+                    collected.Add(line);
+                if (maxLines is int m && collected.Count >= m) break;
+            }
+        }
+        return collected;
+    }
+
+    public OutputBufferStats Snapshot()
+    {
+        lock (_gate)
+            return new OutputBufferStats(_items.Count, _currentBytes, _droppedLines, _maxLines, _maxBytes);
+    }
+
+    /// Rough in-memory size of an OutputLine. Chars are 2 bytes in .NET strings; the
+    /// constant accounts for the record object header, the DateTimeOffset, and the
+    /// category string (typically "stdout"/"stderr"/"console", a handful of bytes interned).
+    private static long EstimateSize(OutputLine line)
+        => (long)(line.Output?.Length ?? 0) * 2 + 80;
+}
+
+public sealed record OutputBufferStats(
+    int Lines,
+    long Bytes,
+    long DroppedLines,
+    int MaxLines,
+    long MaxBytes);

--- a/src/AspNetCoreDebuggerMcp/Debugging/DebugSession.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/DebugSession.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Text.Json;
 using AspNetCoreDebuggerMcp.Breakpoints;
 using AspNetCoreDebuggerMcp.Dap;
@@ -19,7 +18,7 @@ internal sealed class DebugSession : IAsyncDisposable
     private readonly BreakpointRegistry _breakpoints = new();
     private readonly InspectionService _inspector;
     private readonly TraceCollector _trace = new();
-    private readonly ConcurrentQueue<OutputLine> _outputBuffer = new();
+    private readonly BoundedOutputBuffer _outputBuffer = new();
     private IReadOnlyList<string> _exceptionFiltersBeforeTrace = Array.Empty<string>();
     private readonly TaskCompletionSource _initializedTcs =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -31,7 +30,12 @@ internal sealed class DebugSession : IAsyncDisposable
     public int? ProcessId { get { lock (_gate) return _processId; } }
     public StopInfo? LastStop { get { lock (_gate) return _lastStop; } }
 
-    public SessionSnapshot Snapshot() => new(State.ToString(), ProcessId, LastStop);
+    public SessionSnapshot Snapshot() => new(
+        State.ToString(),
+        ProcessId,
+        LastStop,
+        OutputBufferStats(),
+        TraceBufferStats());
     public BreakpointsSnapshot BreakpointsSnapshot() => _breakpoints.Snapshot();
 
     private DebugSession(NetcoredbgProcess process, DapClient client)
@@ -350,16 +354,11 @@ internal sealed class DebugSession : IAsyncDisposable
     // ---- output buffer + hang analysis ----------------------------------------------
 
     public IReadOnlyList<OutputLine> DrainOutput(string? category = null, int? maxLines = null)
-    {
-        var collected = new List<OutputLine>();
-        while (_outputBuffer.TryDequeue(out var line))
-        {
-            if (category is null || string.Equals(line.Category, category, StringComparison.OrdinalIgnoreCase))
-                collected.Add(line);
-            if (maxLines is int m && collected.Count >= m) break;
-        }
-        return collected;
-    }
+        => _outputBuffer.Drain(category, maxLines);
+
+    public OutputBufferStats OutputBufferStats() => _outputBuffer.Snapshot();
+
+    public TraceBufferStats TraceBufferStats() => _trace.BufferStats();
 
     public async Task<HangAnalysis> HangAnalyzeAsync(int topFramesPerThread, CancellationToken ct)
     {
@@ -732,6 +731,8 @@ internal sealed class DebugSession : IAsyncDisposable
         if (output.Length == 0) return;
         _outputBuffer.Enqueue(new OutputLine(category, output, DateTimeOffset.UtcNow));
     }
+
+
 
     private void HandleBreakpointEvent(DapMessage e)
     {

--- a/src/AspNetCoreDebuggerMcp/Debugging/SessionSnapshot.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/SessionSnapshot.cs
@@ -1,3 +1,5 @@
+using AspNetCoreDebuggerMcp.Diagnostics;
+
 namespace AspNetCoreDebuggerMcp.Debugging;
 
 public sealed record StopInfo(string Reason, int? ThreadId, string? Description);
@@ -5,7 +7,9 @@ public sealed record StopInfo(string Reason, int? ThreadId, string? Description)
 public sealed record SessionSnapshot(
     string State,
     int? ProcessId,
-    StopInfo? LastStop)
+    StopInfo? LastStop,
+    OutputBufferStats? OutputBuffer = null,
+    TraceBufferStats? TraceBuffer = null)
 {
     public static SessionSnapshot None { get; } = new("None", null, null);
 }

--- a/src/AspNetCoreDebuggerMcp/Diagnostics/TraceCollector.cs
+++ b/src/AspNetCoreDebuggerMcp/Diagnostics/TraceCollector.cs
@@ -6,11 +6,21 @@ namespace AspNetCoreDebuggerMcp.Diagnostics;
 ///  - the set of function names being traced (used at start to set BPs)
 ///  - the adapter-issued BP ids (used to recognise trace hits in DAP stopped events)
 ///  - whether exception traces are enabled
-///  - the captured TraceEvent log
+///  - the captured TraceEvent log (capped, drop-oldest — see MAG-54)
 internal sealed class TraceCollector
 {
+    public const int DefaultMaxEvents = 50_000;
+
     private readonly object _gate = new();
+    private readonly int _maxEvents;
     private TraceSession? _current;
+    private long _droppedEvents;
+
+    public TraceCollector(int maxEvents = DefaultMaxEvents)
+    {
+        if (maxEvents <= 0) throw new ArgumentOutOfRangeException(nameof(maxEvents));
+        _maxEvents = maxEvents;
+    }
 
     public bool IsActive { get { lock (_gate) return _current is not null; } }
 
@@ -93,7 +103,25 @@ internal sealed class TraceCollector
 
     public void Append(TraceEvent ev)
     {
-        lock (_gate) _current?.Events.Add(ev);
+        lock (_gate)
+        {
+            if (_current is null) return;
+            _current.Events.Add(ev);
+            while (_current.Events.Count > _maxEvents)
+            {
+                _current.Events.RemoveAt(0);
+                _droppedEvents++;
+            }
+        }
+    }
+
+    public TraceBufferStats BufferStats()
+    {
+        lock (_gate)
+        {
+            var count = _current?.Events.Count ?? 0;
+            return new TraceBufferStats(_current is not null, count, _droppedEvents, _maxEvents);
+        }
     }
 
     public long ElapsedMs(DateTimeOffset now)
@@ -136,3 +164,9 @@ public sealed record TraceConfig(
     bool CaptureLocals,
     int MaxFramesPerEvent,
     int MaxLocalsPerFrame);
+
+public sealed record TraceBufferStats(
+    bool Active,
+    int Events,
+    long DroppedEvents,
+    int MaxEvents);

--- a/src/AspNetCoreDebuggerMcp/Tools/SessionTools.cs
+++ b/src/AspNetCoreDebuggerMcp/Tools/SessionTools.cs
@@ -77,6 +77,8 @@ public sealed class SessionTools
         state = snap.State,
         processId = snap.ProcessId,
         lastStop = snap.LastStop,
+        outputBuffer = snap.OutputBuffer,
+        traceBuffer = snap.TraceBuffer,
     }, JsonOpts);
 
     private static string Err(Exception ex)

--- a/tests/AspNetCoreDebuggerMcp.Tests/Debugging/BoundedOutputBufferTests.cs
+++ b/tests/AspNetCoreDebuggerMcp.Tests/Debugging/BoundedOutputBufferTests.cs
@@ -1,0 +1,152 @@
+using AspNetCoreDebuggerMcp.Debugging;
+using AspNetCoreDebuggerMcp.Diagnostics;
+
+namespace AspNetCoreDebuggerMcp.Tests.Debugging;
+
+public class BoundedOutputBufferTests
+{
+    [Fact]
+    public void Enqueue_BelowCaps_KeepsEverything()
+    {
+        var buf = new BoundedOutputBuffer(maxLines: 100, maxBytes: 1_000_000);
+        for (int i = 0; i < 10; i++)
+            buf.Enqueue(Line($"line-{i}"));
+
+        var stats = buf.Snapshot();
+        Assert.Equal(10, stats.Lines);
+        Assert.Equal(0, stats.DroppedLines);
+    }
+
+    [Fact]
+    public void Enqueue_AboveLineCap_DropsOldest()
+    {
+        var buf = new BoundedOutputBuffer(maxLines: 5, maxBytes: 1_000_000);
+        for (int i = 0; i < 8; i++)
+            buf.Enqueue(Line($"line-{i}"));
+
+        var stats = buf.Snapshot();
+        Assert.Equal(5, stats.Lines);
+        Assert.Equal(3, stats.DroppedLines);
+
+        var drained = buf.Drain();
+        Assert.Equal(new[] { "line-3", "line-4", "line-5", "line-6", "line-7" },
+            drained.Select(l => l.Output));
+    }
+
+    [Fact]
+    public void Enqueue_AboveByteCap_DropsOldest()
+    {
+        // Each line below is ~10 chars × 2 bytes + 80 byte overhead ≈ 100 bytes.
+        // maxBytes=300 should fit ~3 lines.
+        var buf = new BoundedOutputBuffer(maxLines: 1000, maxBytes: 300);
+        for (int i = 0; i < 10; i++)
+            buf.Enqueue(Line($"ten-chars-{i}"));
+
+        var stats = buf.Snapshot();
+        Assert.True(stats.Bytes <= 300, $"bytes={stats.Bytes} exceeded cap=300");
+        Assert.True(stats.DroppedLines > 0);
+        // exactly: 10 lines * ~104 bytes = ~1040 bytes; cap drains to <=300 → keeps last 2-3.
+        Assert.InRange(stats.Lines, 2, 4);
+    }
+
+    [Fact]
+    public void Floods_DoNotGrowMemory_Bounded()
+    {
+        // The regression: simulate the MAG-54 scenario — 1,000,000 lines pumped at the
+        // buffer. With a 50,000-line cap, only 50,000 should survive and the rest count
+        // as dropped. (Total bytes here are well below the byte cap, so line cap dominates.)
+        var buf = new BoundedOutputBuffer(maxLines: 50_000, maxBytes: 1024L * 1024 * 1024);
+        for (int i = 0; i < 1_000_000; i++)
+            buf.Enqueue(Line("x"));
+
+        var stats = buf.Snapshot();
+        Assert.Equal(50_000, stats.Lines);
+        Assert.Equal(950_000, stats.DroppedLines);
+    }
+
+    [Fact]
+    public void Drain_RemovesItems_AndResetsByteAccounting()
+    {
+        var buf = new BoundedOutputBuffer(maxLines: 100, maxBytes: 10_000);
+        for (int i = 0; i < 10; i++)
+            buf.Enqueue(Line($"line-{i}"));
+
+        var drained = buf.Drain();
+        Assert.Equal(10, drained.Count);
+
+        var stats = buf.Snapshot();
+        Assert.Equal(0, stats.Lines);
+        Assert.Equal(0, stats.Bytes);
+    }
+
+    [Fact]
+    public void Drain_FilterByCategory_OnlyMatching()
+    {
+        var buf = new BoundedOutputBuffer(maxLines: 100, maxBytes: 1_000_000);
+        buf.Enqueue(new OutputLine("stdout", "a", DateTimeOffset.UtcNow));
+        buf.Enqueue(new OutputLine("stderr", "b", DateTimeOffset.UtcNow));
+        buf.Enqueue(new OutputLine("stdout", "c", DateTimeOffset.UtcNow));
+
+        var stderrLines = buf.Drain(category: "stderr");
+        Assert.Single(stderrLines);
+        Assert.Equal("b", stderrLines[0].Output);
+    }
+
+    [Fact]
+    public void Drain_WithMaxLines_StopsAtLimit()
+    {
+        var buf = new BoundedOutputBuffer(maxLines: 100, maxBytes: 1_000_000);
+        for (int i = 0; i < 10; i++)
+            buf.Enqueue(Line($"line-{i}"));
+
+        var first3 = buf.Drain(maxLines: 3);
+        Assert.Equal(3, first3.Count);
+
+        var rest = buf.Drain();
+        Assert.Equal(7, rest.Count);
+    }
+
+    [Fact]
+    public void Constructor_RejectsNonPositiveCaps()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new BoundedOutputBuffer(maxLines: 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new BoundedOutputBuffer(maxLines: 100, maxBytes: 0));
+    }
+
+    /// MAG-54 regression: pump 200 MB of output through a 4 MB-capped buffer and assert
+    /// that the heap allocation tied to the buffer stays bounded around the cap. Without
+    /// the fix, this would balloon to ~200 MB; with the fix it should hover near the cap
+    /// (well under 50 MB after a forced GC pass).
+    [Fact]
+    public void Flood_DoesNotGrowHeap_HardMemoryBound()
+    {
+        var buf = new BoundedOutputBuffer(maxLines: 10_000, maxBytes: 4L * 1024 * 1024);
+
+        // Establish a baseline after the buffer is constructed.
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        var baseline = GC.GetTotalMemory(forceFullCollection: true);
+
+        // Pump ~200 MB of output: 100,000 lines × ~2 KB each.
+        var bigLine = new string('x', 1024); // 1024 chars × 2 bytes ≈ 2 KB per OutputLine
+        for (int i = 0; i < 100_000; i++)
+            buf.Enqueue(new OutputLine("stdout", bigLine, DateTimeOffset.UtcNow));
+
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        var afterFlood = GC.GetTotalMemory(forceFullCollection: true);
+        var grew = afterFlood - baseline;
+
+        // Bound check: heap growth should be well under 50 MB even though we pumped 200 MB
+        // of payload. The cap is 4 MB but GC + Queue<T> slack pushes this higher in practice.
+        // Without the fix, growth would be ~200 MB.
+        Assert.True(grew < 50L * 1024 * 1024,
+            $"Heap grew by {grew / (1024.0 * 1024.0):F1} MB; expected < 50 MB under a 4 MB cap.");
+
+        var stats = buf.Snapshot();
+        Assert.True(stats.Bytes <= buf.Snapshot().MaxBytes, "byte count exceeded cap");
+        Assert.True(stats.DroppedLines > 0, "expected drops under flood");
+    }
+
+    private static OutputLine Line(string text) =>
+        new OutputLine("stdout", text, DateTimeOffset.UtcNow);
+}

--- a/tests/AspNetCoreDebuggerMcp.Tests/Diagnostics/TraceCollectorTests.cs
+++ b/tests/AspNetCoreDebuggerMcp.Tests/Diagnostics/TraceCollectorTests.cs
@@ -88,4 +88,31 @@ public class TraceCollectorTests
         c.Start(new[] { "Foo" }, true, true, includeExceptions: true, 10, 10);
         Assert.True(c.ExceptionTracingEnabled);
     }
+
+    [Fact]
+    public void Append_BeyondMaxEvents_DropsOldest()
+    {
+        var c = new TraceCollector(maxEvents: 5);
+        c.Start(new[] { "Foo" }, true, true, true, 10, 10);
+        for (int i = 0; i < 10; i++)
+            c.Append(new TraceEvent(i, TraceEventKind.Enter, 1, $"M{i}", null, null, null, null));
+
+        var stats = c.BufferStats();
+        Assert.True(stats.Active);
+        Assert.Equal(5, stats.Events);
+        Assert.Equal(5, stats.DroppedEvents);
+
+        var events = c.Events();
+        Assert.Equal(new[] { "M5", "M6", "M7", "M8", "M9" }, events.Select(e => e.Method));
+    }
+
+    [Fact]
+    public void BufferStats_BeforeStart_ReportsInactive()
+    {
+        var c = new TraceCollector();
+        var stats = c.BufferStats();
+        Assert.False(stats.Active);
+        Assert.Equal(0, stats.Events);
+        Assert.Equal(0, stats.DroppedEvents);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes [MAG-54](https://linear.app/magna-nz/issue/MAG-54). The `DebugSession` output buffer was an unbounded `ConcurrentQueue<OutputLine>` — a debuggee in a hot `Console.WriteLine` / exception-logging loop pumped enough output to balloon the host process to ~38 GB in minutes and force a hard reboot.

- Add `BoundedOutputBuffer` (drop-oldest, capped on **both** lines and bytes — defaults 50k lines / 64 MB).
- Wire `DebugSession._outputBuffer` to it; remove `ConcurrentQueue` usage.
- Cap `TraceCollector` event list with the same drop-oldest pattern (50k default).
- Surface `outputBuffer` + `traceBuffer` stats (count, bytes, dropped) on `SessionSnapshot` → visible via `debug_state` so the agent can see when output is being dropped.

## Why both caps

Line cap alone leaves a hole: a single rare-but-huge output line (multi-MB stack dump) can still spike memory. Byte cap alone admits unlimited tiny lines. Either trigger evicts oldest.

## Test plan

- [x] `dotnet build` — clean (0 warnings, 0 errors)
- [x] `dotnet test` — 107 / 107 passing
- [x] **Heap-bound regression test** (`Flood_DoesNotGrowHeap_HardMemoryBound`): pumps 200 MB through a 4 MB-capped buffer, asserts heap growth < 50 MB after forced GC. Without the fix this would balloon to ~200 MB.
- [x] **Flood-by-count test**: 1,000,000 lines into a 50k-cap buffer → exactly 50k retained, 950k dropped.
- [x] **Byte-cap test**: lines exceeding the byte cap evict oldest while line cap isn't yet hit.
- [x] **TraceCollector cap test**: 10 events into a 5-event cap → 5 retained, 5 dropped, oldest gone.
- [x] Second-pass audit: no other unbounded collections (BreakpointRegistry, DapClient `_pending`, TraceCollector `_adapterIds` all bounded by user actions or in-flight count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)