### PR TITLE
Bust GitHub camo cache on the downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![CI](https://github.com/magna-nz/aspnetcore-debugger-mcp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/magna-nz/aspnetcore-debugger-mcp/actions/workflows/ci.yml)
 [![NuGet](https://img.shields.io/nuget/vpre/AspNetCoreDebuggerMcp.svg?label=NuGet)](https://www.nuget.org/packages/AspNetCoreDebuggerMcp)
-[![Downloads](https://img.shields.io/nuget/dt/AspNetCoreDebuggerMcp.svg?label=downloads)](https://www.nuget.org/packages/AspNetCoreDebuggerMcp)
+[![Downloads](https://img.shields.io/nuget/dt/AspNetCoreDebuggerMcp.svg?label=downloads&v=2)](https://www.nuget.org/packages/AspNetCoreDebuggerMcp)
 [![.NET](https://img.shields.io/badge/.NET-10-512BD4)](https://dotnet.microsoft.com/)
 [![MCP](https://img.shields.io/badge/MCP-compatible-005FBA)](https://modelcontextprotocol.io/)
 [![Platforms](https://img.shields.io/badge/runs%20on-Linux%20%7C%20macOS%20%7C%20Windows-success)](#platforms)


### PR DESCRIPTION
## Summary

- shields.io is reporting the live count (`379` as of now).
- GitHub's camo proxy cached an earlier SVG when the count was `290` and is still serving those bytes, so the README shows a stale number.
- Append a no-op `v=2` query parameter to change the camo cache key. shields.io ignores unknown params, so the rendered badge is unchanged — only the proxy key changes, forcing a fresh fetch.

Same trick we used on the Glama badge in #26.

## Test plan

- [x] `curl https://img.shields.io/nuget/dt/AspNetCoreDebuggerMcp.json` returns `value: "379"` (matches NuGet API).
- [ ] After merge, the rendered README on github.com shows the current download count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)