### PR TITLE
Use cacheSeconds=3600 on the downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![CI](https://github.com/magna-nz/aspnetcore-debugger-mcp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/magna-nz/aspnetcore-debugger-mcp/actions/workflows/ci.yml)
 [![NuGet](https://img.shields.io/nuget/vpre/AspNetCoreDebuggerMcp.svg?label=NuGet)](https://www.nuget.org/packages/AspNetCoreDebuggerMcp)
-[![Downloads](https://img.shields.io/nuget/dt/AspNetCoreDebuggerMcp.svg?label=downloads&v=2)](https://www.nuget.org/packages/AspNetCoreDebuggerMcp)
+[![Downloads](https://img.shields.io/nuget/dt/AspNetCoreDebuggerMcp.svg?label=downloads&cacheSeconds=3600)](https://www.nuget.org/packages/AspNetCoreDebuggerMcp)
 [![.NET](https://img.shields.io/badge/.NET-10-512BD4)](https://dotnet.microsoft.com/)
 [![MCP](https://img.shields.io/badge/MCP-compatible-005FBA)](https://modelcontextprotocol.io/)
 [![Platforms](https://img.shields.io/badge/runs%20on-Linux%20%7C%20macOS%20%7C%20Windows-success)](#platforms)


### PR DESCRIPTION
## Summary

Follow-up to #30. That PR busted GitHub's camo proxy cache once via `?v=2`, but the badge has drifted again — currently rendering **290** while NuGet is at **443**.

Root cause: shields.io's NuGet downloads endpoint defaults to a multi-hour cache, and Cloudflare's regional edges fall out of sync. When camo refetches (every 30 min), it can hit a stale shields.io edge and re-cache 290 for another 30 min.

`cacheSeconds=3600` fixes both ends:
- Changes the URL hash → forces camo to refetch right now.
- Tells shields.io to cap per-URL caching at 1 hour → regional edges converge fast.

Worst-case staleness after this: ~1.5 hours (1h shields + 30m camo). Was effectively unbounded before.

## Test plan

- [x] `curl 'https://img.shields.io/nuget/dt/AspNetCoreDebuggerMcp.svg?label=downloads&cacheSeconds=3600'` returns `>443</text>`.
- [ ] Rendered README shows current count after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)