### PR TITLE
Enrich breakpoint_wait with top-frame locals and recent output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ artifacts/
 .netcoredbg-build/
 external/netcoredbg/build/
 
+# netcoredbg CLI history (written when the bundled binary runs in CLI mode)
+.netcoredbg_hist
+
 # Bundled netcoredbg binaries — populated by scripts/fetch-netcoredbg-binaries.sh
 # (CI runs this before `dotnet pack`). Out of git to keep repo light.
 src/AspNetCoreDebuggerMcp/runtimes/

--- a/src/AspNetCoreDebuggerMcp/Debugging/BoundedOutputBuffer.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/BoundedOutputBuffer.cs
@@ -63,6 +63,25 @@ internal sealed class BoundedOutputBuffer
         return collected;
     }
 
+    /// Non-destructive snapshot of the most recent matching lines, in chronological
+    /// order (oldest first). Used by composite tools (e.g. breakpoint_wait) that want
+    /// to surface "what just printed" without disturbing a caller's drain pattern.
+    public IReadOnlyList<OutputLine> PeekRecent(int maxLines, string? category = null)
+    {
+        if (maxLines <= 0) return Array.Empty<OutputLine>();
+        lock (_gate)
+        {
+            if (_items.Count == 0) return Array.Empty<OutputLine>();
+            IEnumerable<OutputLine> source = _items;
+            if (category is not null)
+                source = source.Where(l => string.Equals(l.Category, category, StringComparison.OrdinalIgnoreCase));
+            // Materialise inside the lock; the queue may mutate the moment we release it.
+            var filtered = source as IReadOnlyCollection<OutputLine> ?? source.ToList();
+            if (filtered.Count <= maxLines) return filtered.ToList();
+            return filtered.Skip(filtered.Count - maxLines).ToList();
+        }
+    }
+
     public OutputBufferStats Snapshot()
     {
         lock (_gate)

--- a/src/AspNetCoreDebuggerMcp/Debugging/DebugSession.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/DebugSession.cs
@@ -356,6 +356,9 @@ internal sealed class DebugSession : IAsyncDisposable
     public IReadOnlyList<OutputLine> DrainOutput(string? category = null, int? maxLines = null)
         => _outputBuffer.Drain(category, maxLines);
 
+    public IReadOnlyList<OutputLine> PeekRecentOutput(int maxLines, string? category = null)
+        => _outputBuffer.PeekRecent(maxLines, category);
+
     public OutputBufferStats OutputBufferStats() => _outputBuffer.Snapshot();
 
     public TraceBufferStats TraceBufferStats() => _trace.BufferStats();

--- a/src/AspNetCoreDebuggerMcp/Debugging/DebugSessionManager.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/DebugSessionManager.cs
@@ -5,12 +5,15 @@ using AspNetCoreDebuggerMcp.Inspection;
 namespace AspNetCoreDebuggerMcp.Debugging;
 
 /// Combined result of a wait-for-stop call: the stop event, the current session snapshot,
-/// and auto-context (top frame + source snippet) when the stopped thread is known.
+/// and auto-context (top frame, source snippet, top-frame locals, and recent debuggee
+/// output) when the stopped thread is known. Locals and recent output are opt-in via caps.
 public sealed record WaitResult(
     StopInfo Stop,
     SessionSnapshot Session,
     StackFrame? TopFrame,
-    SourceSnippet? Snippet);
+    SourceSnippet? Snippet,
+    IReadOnlyList<ScopeWithVariables>? TopFrameLocals,
+    IReadOnlyList<OutputLine>? RecentOutput);
 
 /// Holds the single active debug session. Session-lifecycle calls (launch/attach/disconnect)
 /// are serialised under a semaphore so concurrent tool invocations cannot race. Within a session,
@@ -93,14 +96,18 @@ public sealed class DebugSessionManager : IAsyncDisposable
         return s.Snapshot();
     }
 
-    public async Task<WaitResult> WaitForStopAsync(TimeSpan timeout, CancellationToken ct)
+    public async Task<WaitResult> WaitForStopAsync(
+        TimeSpan timeout, int maxLocalsPerScope, int maxRecentOutputLines, CancellationToken ct)
     {
         var s = RequireActiveSession();
         var stop = await s.WaitForStopAsync(timeout, ct).ConfigureAwait(false);
 
-        // Auto-context-on-stop: best-effort top frame + source snippet for the stopped thread.
+        // Auto-context-on-stop: best-effort top frame, source snippet, top-frame locals,
+        // and a peek of recent debuggee output — all opportunistic. Failures here must not
+        // turn a successful stop into a tool error; the agent still needs the StopInfo.
         StackFrame? topFrame = null;
         SourceSnippet? snippet = null;
+        IReadOnlyList<ScopeWithVariables>? topLocals = null;
         if (stop.ThreadId is int tid)
         {
             try { topFrame = await s.GetTopFrameAsync(tid, ct).ConfigureAwait(false); }
@@ -108,9 +115,25 @@ public sealed class DebugSessionManager : IAsyncDisposable
 
             if (topFrame is { SourcePath: { } path, Line: int line })
                 snippet = InspectionService.TryReadSnippet(path, line);
+
+            if (topFrame is not null && maxLocalsPerScope > 0)
+            {
+                try
+                {
+                    topLocals = await s.GetScopesAsync(
+                        topFrame.Id, depth: 1, maxChildren: maxLocalsPerScope, ct)
+                        .ConfigureAwait(false);
+                }
+                catch { /* best-effort */ }
+            }
         }
 
-        return new WaitResult(stop, s.Snapshot(), topFrame, snippet);
+        // Non-destructive peek so existing process_read_output flows aren't disturbed.
+        IReadOnlyList<OutputLine>? recentOutput = maxRecentOutputLines > 0
+            ? s.PeekRecentOutput(maxRecentOutputLines)
+            : null;
+
+        return new WaitResult(stop, s.Snapshot(), topFrame, snippet, topLocals, recentOutput);
     }
 
     // ---- inspection passthroughs ---------------------------------------------------

--- a/src/AspNetCoreDebuggerMcp/Tools/ExecutionTools.cs
+++ b/src/AspNetCoreDebuggerMcp/Tools/ExecutionTools.cs
@@ -8,6 +8,8 @@ namespace AspNetCoreDebuggerMcp.Tools;
 public sealed class ExecutionTools
 {
     private const int DefaultWaitTimeoutSeconds = 30;
+    private const int DefaultMaxLocalsPerScope = 30;
+    private const int DefaultMaxRecentOutputLines = 50;
 
     private readonly DebugSessionManager _manager;
 
@@ -57,15 +59,19 @@ public sealed class ExecutionTools
     }
 
     [McpServerTool(Name = "breakpoint_wait")]
-    [Description("Block until the debuggee hits a breakpoint, completes a step, or otherwise stops. Returns the stop info plus auto-context: the topmost stack frame and a source snippet around the stop.")]
+    [Description("Block until the debuggee hits a breakpoint, completes a step, or otherwise stops. Returns the stop info plus a full one-shot snapshot: the topmost stack frame, a source snippet around the stop, top-frame locals, and a peek of recent debuggee stdout/stderr (non-destructive — process_read_output still drains the full buffer). Designed so an agent in a step-inspect loop doesn't need separate inspect / read-output round trips.")]
     public async Task<string> WaitAsync(
         [Description("Maximum seconds to wait. Defaults to 30.")] int? timeoutSeconds = null,
+        [Description("Cap on locals returned per scope on the top frame. Default 30. Pass 0 to omit locals entirely.")] int? maxLocalsPerScope = null,
+        [Description("Cap on recent debuggee output lines included with the stop (peeked, not drained). Default 50. Pass 0 to omit output.")] int? maxRecentOutputLines = null,
         CancellationToken ct = default)
     {
         try
         {
             var timeout = TimeSpan.FromSeconds(timeoutSeconds ?? DefaultWaitTimeoutSeconds);
-            var result = await _manager.WaitForStopAsync(timeout, ct).ConfigureAwait(false);
+            var localsCap = Math.Max(0, maxLocalsPerScope ?? DefaultMaxLocalsPerScope);
+            var outputCap = Math.Max(0, maxRecentOutputLines ?? DefaultMaxRecentOutputLines);
+            var result = await _manager.WaitForStopAsync(timeout, localsCap, outputCap, ct).ConfigureAwait(false);
             return ToolResults.Serialize(new
             {
                 success = true,
@@ -74,6 +80,8 @@ public sealed class ExecutionTools
                 processId = result.Session.ProcessId,
                 topFrame = result.TopFrame,
                 snippet = result.Snippet,
+                topFrameLocals = result.TopFrameLocals,
+                recentOutput = result.RecentOutput,
             });
         }
         catch (OperationCanceledException)

--- a/tests/AspNetCoreDebuggerMcp.Tests/Debugging/BoundedOutputBufferTests.cs
+++ b/tests/AspNetCoreDebuggerMcp.Tests/Debugging/BoundedOutputBufferTests.cs
@@ -147,6 +147,79 @@ public class BoundedOutputBufferTests
         Assert.True(stats.DroppedLines > 0, "expected drops under flood");
     }
 
+    [Fact]
+    public void PeekRecent_ReturnsLastN_InChronologicalOrder()
+    {
+        var buf = new BoundedOutputBuffer(maxLines: 100, maxBytes: 1_000_000);
+        for (int i = 0; i < 10; i++)
+            buf.Enqueue(Line($"line-{i}"));
+
+        var peek = buf.PeekRecent(maxLines: 3);
+        Assert.Equal(new[] { "line-7", "line-8", "line-9" }, peek.Select(l => l.Output));
+    }
+
+    [Fact]
+    public void PeekRecent_IsNonDestructive()
+    {
+        var buf = new BoundedOutputBuffer(maxLines: 100, maxBytes: 1_000_000);
+        for (int i = 0; i < 5; i++)
+            buf.Enqueue(Line($"line-{i}"));
+
+        _ = buf.PeekRecent(maxLines: 2);
+
+        // A subsequent drain must see every line — peek must not have consumed any.
+        var drained = buf.Drain();
+        Assert.Equal(5, drained.Count);
+        Assert.Equal(new[] { "line-0", "line-1", "line-2", "line-3", "line-4" },
+            drained.Select(l => l.Output));
+    }
+
+    [Fact]
+    public void PeekRecent_LargerThanBuffer_ReturnsAll()
+    {
+        var buf = new BoundedOutputBuffer(maxLines: 100, maxBytes: 1_000_000);
+        for (int i = 0; i < 3; i++)
+            buf.Enqueue(Line($"line-{i}"));
+
+        var peek = buf.PeekRecent(maxLines: 50);
+        Assert.Equal(3, peek.Count);
+        Assert.Equal(new[] { "line-0", "line-1", "line-2" }, peek.Select(l => l.Output));
+    }
+
+    [Fact]
+    public void PeekRecent_RespectsCategoryFilter()
+    {
+        var buf = new BoundedOutputBuffer(maxLines: 100, maxBytes: 1_000_000);
+        buf.Enqueue(new OutputLine("stdout", "out-1", DateTimeOffset.UtcNow));
+        buf.Enqueue(new OutputLine("stderr", "err-1", DateTimeOffset.UtcNow));
+        buf.Enqueue(new OutputLine("stdout", "out-2", DateTimeOffset.UtcNow));
+        buf.Enqueue(new OutputLine("stderr", "err-2", DateTimeOffset.UtcNow));
+        buf.Enqueue(new OutputLine("stdout", "out-3", DateTimeOffset.UtcNow));
+
+        var peek = buf.PeekRecent(maxLines: 2, category: "stderr");
+        Assert.Equal(new[] { "err-1", "err-2" }, peek.Select(l => l.Output));
+    }
+
+    [Fact]
+    public void PeekRecent_NonPositive_ReturnsEmpty()
+    {
+        var buf = new BoundedOutputBuffer(maxLines: 100, maxBytes: 1_000_000);
+        buf.Enqueue(Line("a"));
+
+        Assert.Empty(buf.PeekRecent(maxLines: 0));
+        Assert.Empty(buf.PeekRecent(maxLines: -5));
+
+        // Buffer still intact.
+        Assert.Equal(1, buf.Snapshot().Lines);
+    }
+
+    [Fact]
+    public void PeekRecent_EmptyBuffer_ReturnsEmpty()
+    {
+        var buf = new BoundedOutputBuffer(maxLines: 100, maxBytes: 1_000_000);
+        Assert.Empty(buf.PeekRecent(maxLines: 10));
+    }
+
     private static OutputLine Line(string text) =>
         new OutputLine("stdout", text, DateTimeOffset.UtcNow);
 }

--- a/tests/AspNetCoreDebuggerMcp.Tests/Integration/BundledNetcoredbgEndToEndTests.cs
+++ b/tests/AspNetCoreDebuggerMcp.Tests/Integration/BundledNetcoredbgEndToEndTests.cs
@@ -70,6 +70,64 @@ public class BundledNetcoredbgEndToEndTests
     }
 
     [Fact]
+    public async Task Manager_WaitForStop_ReturnsTopFrameLocalsAndRecentOutput()
+    {
+        var bundled = LocateBundledNetcoredbg();
+        if (bundled is null) return;  // skip — see other test
+
+        var webApiDll = LocateBuiltAssembly("SampleWebApi");
+        var programCs = LocateSourceFile("SampleWebApi", "Program.cs");
+        var port = GetFreeTcpPort();
+        var baseUrl = $"http://127.0.0.1:{port}";
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        await using var manager = new DebugSessionManager();
+
+        await manager.LaunchAsync(
+            program: webApiDll,
+            args: new[] { "--urls", baseUrl },
+            cwd: Path.GetDirectoryName(webApiDll),
+            stopAtEntry: false,
+            env: null,
+            cts.Token);
+
+        const int handlerLine = 6;
+        await manager.AddLineBreakpointAsync(
+            sourcePath: programCs, line: handlerLine,
+            condition: null, hitCondition: null, logMessage: null, cts.Token);
+
+        await WaitForWebApiReadyAsync(baseUrl, cts.Token);
+
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+        var requestTask = http.GetAsync($"{baseUrl}/users/42", cts.Token);
+
+        var result = await manager.WaitForStopAsync(
+            timeout: TimeSpan.FromSeconds(20),
+            maxLocalsPerScope: 30,
+            maxRecentOutputLines: 50,
+            cts.Token);
+
+        Assert.Equal("breakpoint", result.Stop.Reason);
+        Assert.NotNull(result.TopFrame);
+
+        // The new enriched fields — the whole point of this test.
+        Assert.NotNull(result.TopFrameLocals);
+        var allVars = result.TopFrameLocals!.SelectMany(s => s.Variables).ToList();
+        Assert.Contains(allVars, v => v.Name == "id" && v.Value == "42");
+
+        // RecentOutput is non-null whenever the cap is > 0. ASP.NET Core's startup
+        // banner ("Now listening on…" / "Application started.") almost always lands
+        // in the buffer before the BP hits, but it's racy — assert structure, not count.
+        Assert.NotNull(result.RecentOutput);
+
+        await manager.ContinueAsync(result.Stop.ThreadId, cts.Token);
+        var response = await requestTask;
+        Assert.True(response.IsSuccessStatusCode);
+
+        await manager.DisconnectAsync(cts.Token);
+    }
+
+    [Fact]
     public async Task DebugSession_PassesEnvironmentVariables_ToDebuggee()
     {
         var bundled = LocateBundledNetcoredbg();


### PR DESCRIPTION
## Summary

A single `breakpoint_wait` call now returns top-frame locals (depth 1) and a non-destructive peek of recent debuggee stdout/stderr alongside the existing stop info, top frame, and source snippet — so an agent in a step-inspect loop doesn't need to orchestrate separate `variables_get` + `process_read_output` calls.

Motivated by external feedback that interactive debug MCPs tend to drift after 3-4 step cycles because each cycle costs multiple inspect round-trips. Folding the snapshot into the wait response shrinks that surface area.

## What changed

- `BoundedOutputBuffer.PeekRecent(maxLines, category?)` — non-destructive snapshot of the most recent matching lines in chronological order.
- `DebugSessionManager.WaitForStopAsync` now takes `maxLocalsPerScope` and `maxRecentOutputLines`; after the stop arrives, best-effort fetches scopes for the top frame and peeks recent output. Failures here never turn a successful stop into a tool error.
- `WaitResult` record gains `TopFrameLocals` and `RecentOutput`.
- `breakpoint_wait` tool gains two optional params (`maxLocalsPerScope` default 30, `maxRecentOutputLines` default 50; pass 0 to omit each). Tool description updated to explain the full one-shot snapshot.

## Behaviour notes

- `recentOutput` is a **peek**, not a drain. `process_read_output` still drains the full buffer — existing log-capture flows are unaffected.
- Locals fetch reuses the same `GetScopesAsync` path used by `exception_autopsy` and `stack_explore` — no new DAP surface area.
- No change to `DebugSession.WaitForStopAsync` (the session-level method); only the manager wrapper grew the new params.

## Test plan

- [x] 6 new unit tests on `BoundedOutputBuffer.PeekRecent` (ordering, non-destructive, oversize, category filter, non-positive cap, empty)
- [x] New integration test `Manager_WaitForStop_ReturnsTopFrameLocalsAndRecentOutput` against bundled netcoredbg — asserts BP hit, `TopFrameLocals` contains `id=42`, and `RecentOutput` populates
- [x] Full suite green locally: 114/114
- [ ] CI green on ubuntu-latest + macos-latest