### PR TITLE
Enrich debug_step and exception_autopsy with one-shot snapshots

### DIFF
--- a/src/AspNetCoreDebuggerMcp/Debugging/DebugSessionManager.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/DebugSessionManager.cs
@@ -216,6 +216,9 @@ public sealed class DebugSessionManager : IAsyncDisposable
     public IReadOnlyList<OutputLine> DrainOutput(string? category, int? maxLines)
         => _session?.DrainOutput(category, maxLines) ?? Array.Empty<OutputLine>();
 
+    public IReadOnlyList<OutputLine> PeekRecentOutput(int maxLines, string? category = null)
+        => _session?.PeekRecentOutput(maxLines, category) ?? Array.Empty<OutputLine>();
+
     private int ResolveThreadIdOrThrow(int? threadId)
     {
         if (threadId is int id) return id;

--- a/src/AspNetCoreDebuggerMcp/Tools/ExecutionTools.cs
+++ b/src/AspNetCoreDebuggerMcp/Tools/ExecutionTools.cs
@@ -44,16 +44,46 @@ public sealed class ExecutionTools
     }
 
     [McpServerTool(Name = "debug_step")]
-    [Description("Single-step the debuggee. Kind: \"in\" (step into), \"over\" (step over), \"out\" (step out).")]
+    [Description("Single-step the debuggee. Kind: \"in\" (step into), \"over\" (step over), \"out\" (step out). Pass `waitTimeoutSeconds` > 0 to also block on the next stop and return the same one-shot snapshot as `breakpoint_wait` (top frame, snippet, top-frame locals, recent debuggee output). Without it the call returns immediately after issuing the step — today's behavior.")]
     public async Task<string> StepAsync(
         [Description("Step kind: \"in\", \"over\", or \"out\".")] string kind,
         [Description("Thread id to step. If omitted, uses the last thread that stopped.")] int? threadId = null,
+        [Description("Seconds to wait for the resulting stop. 0 (default) returns immediately after issuing the step. > 0 blocks and returns the full enriched stop snapshot.")] int? waitTimeoutSeconds = null,
+        [Description("Cap on locals returned per scope on the top frame after the post-step stop. Default 30. Pass 0 to omit locals. Only used when waitTimeoutSeconds > 0.")] int? maxLocalsPerScope = null,
+        [Description("Cap on recent debuggee output lines included with the post-step stop (peeked, not drained). Default 50. Pass 0 to omit output. Only used when waitTimeoutSeconds > 0.")] int? maxRecentOutputLines = null,
         CancellationToken ct = default)
     {
         try
         {
             var snap = await _manager.StepAsync(kind, threadId, ct).ConfigureAwait(false);
-            return ToolResults.Serialize(new { success = true, state = snap.State });
+            int waitSeconds = waitTimeoutSeconds ?? 0;
+            if (waitSeconds <= 0)
+            {
+                return ToolResults.Serialize(new { success = true, state = snap.State });
+            }
+
+            var timeout = TimeSpan.FromSeconds(waitSeconds);
+            var localsCap = Math.Max(0, maxLocalsPerScope ?? DefaultMaxLocalsPerScope);
+            var outputCap = Math.Max(0, maxRecentOutputLines ?? DefaultMaxRecentOutputLines);
+            try
+            {
+                var result = await _manager.WaitForStopAsync(timeout, localsCap, outputCap, ct).ConfigureAwait(false);
+                return ToolResults.Serialize(new
+                {
+                    success = true,
+                    stop = result.Stop,
+                    state = result.Session.State,
+                    processId = result.Session.ProcessId,
+                    topFrame = result.TopFrame,
+                    snippet = result.Snippet,
+                    topFrameLocals = result.TopFrameLocals,
+                    recentOutput = result.RecentOutput,
+                });
+            }
+            catch (OperationCanceledException)
+            {
+                return ToolResults.Serialize(new { success = false, error = "timeout", state = _manager.GetState().State });
+            }
         }
         catch (Exception ex) { return ToolResults.Err(ex); }
     }

--- a/src/AspNetCoreDebuggerMcp/Tools/InspectionTools.cs
+++ b/src/AspNetCoreDebuggerMcp/Tools/InspectionTools.cs
@@ -10,6 +10,7 @@ public sealed class InspectionTools
     private const int DefaultDepth = 1;
     private const int DefaultMaxChildren = 50;
     private const int DefaultAutopsyFrameCount = 20;
+    private const int DefaultMaxRecentOutputLines = 50;
 
     private readonly DebugSessionManager _manager;
 
@@ -115,17 +116,20 @@ public sealed class InspectionTools
     }
 
     [McpServerTool(Name = "exception_autopsy")]
-    [Description("Full exception context in one call: exception type + inner-exception chain + top stack frames + top frame's locals + source snippet around the throw. Call this when state.lastStop.reason == \"exception\".")]
+    [Description("Full exception context in one call: exception type + inner-exception chain + top stack frames + top frame's locals + source snippet around the throw + a peek of recent debuggee stdout/stderr (non-destructive — process_read_output still drains the full buffer). Call this when state.lastStop.reason == \"exception\".")]
     public async Task<string> AutopsyAsync(
         [Description("Thread id. Defaults to the last-stopped thread.")] int? threadId = null,
         [Description("How many top stack frames to include. Default 20.")] int? frameCount = null,
+        [Description("Cap on recent debuggee output lines included with the autopsy (peeked, not drained). Default 50. Pass 0 to omit output.")] int? maxRecentOutputLines = null,
         CancellationToken ct = default)
     {
         try
         {
             var autopsy = await _manager.AutopsyAsync(
                 threadId, frameCount ?? DefaultAutopsyFrameCount, ct).ConfigureAwait(false);
-            return ToolResults.Serialize(new { success = true, autopsy });
+            var outputCap = Math.Max(0, maxRecentOutputLines ?? DefaultMaxRecentOutputLines);
+            var recentOutput = outputCap > 0 ? _manager.PeekRecentOutput(outputCap) : null;
+            return ToolResults.Serialize(new { success = true, autopsy, recentOutput });
         }
         catch (Exception ex) { return ToolResults.Err(ex); }
     }

--- a/tests/AspNetCoreDebuggerMcp.Tests/Integration/BundledNetcoredbgEndToEndTests.cs
+++ b/tests/AspNetCoreDebuggerMcp.Tests/Integration/BundledNetcoredbgEndToEndTests.cs
@@ -1,7 +1,9 @@
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 using AspNetCoreDebuggerMcp.Debugging;
+using AspNetCoreDebuggerMcp.Tools;
 
 namespace AspNetCoreDebuggerMcp.Tests.Integration;
 
@@ -124,6 +126,228 @@ public class BundledNetcoredbgEndToEndTests
         var response = await requestTask;
         Assert.True(response.IsSuccessStatusCode);
 
+        await manager.DisconnectAsync(cts.Token);
+    }
+
+    [Fact]
+    public async Task Tool_DebugStep_DefaultReturnsSimpleShape_NoEnrichment()
+    {
+        // Regression guard: when called without waitTimeoutSeconds, debug_step must
+        // return ONLY { success, state } — the same shape it returned before this PR.
+        // After issuing the no-wait step we still need a WaitForStop to let the step
+        // settle before resuming, because manager.StepAsync only awaits the DAP ack,
+        // not the resulting stop event — that's the exact "old pattern" agents use today.
+
+        var bundled = LocateBundledNetcoredbg();
+        if (bundled is null) return;
+
+        var webApiDll = LocateBuiltAssembly("SampleWebApi");
+        var programCs = LocateSourceFile("SampleWebApi", "Program.cs");
+        var port = GetFreeTcpPort();
+        var baseUrl = $"http://127.0.0.1:{port}";
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        await using var manager = new DebugSessionManager();
+        var execTools = new ExecutionTools(manager);
+
+        await manager.LaunchAsync(
+            program: webApiDll, args: new[] { "--urls", baseUrl },
+            cwd: Path.GetDirectoryName(webApiDll), stopAtEntry: false, env: null, cts.Token);
+
+        const int handlerLine = 6;
+        await manager.AddLineBreakpointAsync(
+            sourcePath: programCs, line: handlerLine,
+            condition: null, hitCondition: null, logMessage: null, cts.Token);
+
+        await WaitForWebApiReadyAsync(baseUrl, cts.Token);
+
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+        var requestTask = http.GetAsync($"{baseUrl}/users/42", cts.Token);
+
+        var stop = await manager.WaitForStopAsync(
+            timeout: TimeSpan.FromSeconds(20),
+            maxLocalsPerScope: 30, maxRecentOutputLines: 50, cts.Token);
+        Assert.Equal("breakpoint", stop.Stop.Reason);
+
+        // Default (no wait): tool returns ONLY success + state. No enrichment fields.
+        var defaultJson = await execTools.StepAsync(
+            kind: "over", threadId: stop.Stop.ThreadId,
+            waitTimeoutSeconds: null, maxLocalsPerScope: null, maxRecentOutputLines: null,
+            ct: cts.Token);
+        using (var doc = JsonDocument.Parse(defaultJson))
+        {
+            var root = doc.RootElement;
+            Assert.True(root.GetProperty("success").GetBoolean());
+            Assert.True(root.TryGetProperty("state", out _));
+            Assert.False(root.TryGetProperty("topFrame", out _),
+                "default debug_step (no wait) must not include enrichment fields");
+            Assert.False(root.TryGetProperty("topFrameLocals", out _));
+            Assert.False(root.TryGetProperty("recentOutput", out _));
+            Assert.False(root.TryGetProperty("stop", out _));
+        }
+
+        // Settle the step (this is the agent flow today: step, then wait separately),
+        // then resume so the request can complete.
+        var postStep = await manager.WaitForStopAsync(
+            timeout: TimeSpan.FromSeconds(20),
+            maxLocalsPerScope: 0, maxRecentOutputLines: 0, cts.Token);
+        Assert.Equal("step", postStep.Stop.Reason);
+
+        await manager.ContinueAsync(postStep.Stop.ThreadId, cts.Token);
+        var response = await requestTask;
+        Assert.True(response.IsSuccessStatusCode);
+        await manager.DisconnectAsync(cts.Token);
+    }
+
+    [Fact]
+    public async Task Tool_DebugStep_OptInWaitReturnsEnrichedSnapshot()
+    {
+        // The headline feature: pass waitTimeoutSeconds and debug_step returns the same
+        // one-shot snapshot as breakpoint_wait (stop, topFrame, snippet, locals, recentOutput)
+        // — one tool call instead of two.
+
+        var bundled = LocateBundledNetcoredbg();
+        if (bundled is null) return;
+
+        var webApiDll = LocateBuiltAssembly("SampleWebApi");
+        var programCs = LocateSourceFile("SampleWebApi", "Program.cs");
+        var port = GetFreeTcpPort();
+        var baseUrl = $"http://127.0.0.1:{port}";
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        await using var manager = new DebugSessionManager();
+        var execTools = new ExecutionTools(manager);
+
+        await manager.LaunchAsync(
+            program: webApiDll, args: new[] { "--urls", baseUrl },
+            cwd: Path.GetDirectoryName(webApiDll), stopAtEntry: false, env: null, cts.Token);
+
+        const int handlerLine = 6;
+        await manager.AddLineBreakpointAsync(
+            sourcePath: programCs, line: handlerLine,
+            condition: null, hitCondition: null, logMessage: null, cts.Token);
+
+        await WaitForWebApiReadyAsync(baseUrl, cts.Token);
+
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+        var requestTask = http.GetAsync($"{baseUrl}/users/42", cts.Token);
+
+        var stop = await manager.WaitForStopAsync(
+            timeout: TimeSpan.FromSeconds(20),
+            maxLocalsPerScope: 30, maxRecentOutputLines: 50, cts.Token);
+        Assert.Equal("breakpoint", stop.Stop.Reason);
+
+        var enrichedJson = await execTools.StepAsync(
+            kind: "over", threadId: stop.Stop.ThreadId,
+            waitTimeoutSeconds: 20, maxLocalsPerScope: 30, maxRecentOutputLines: 50,
+            ct: cts.Token);
+
+        int postStepThreadId;
+        using (var doc = JsonDocument.Parse(enrichedJson))
+        {
+            var root = doc.RootElement;
+            Assert.True(root.GetProperty("success").GetBoolean(),
+                $"opt-in step+wait failed: {enrichedJson}");
+
+            Assert.True(root.TryGetProperty("stop", out var stopEl));
+            Assert.Equal("step", stopEl.GetProperty("reason").GetString());
+            Assert.True(root.TryGetProperty("topFrame", out _));
+            Assert.True(root.TryGetProperty("topFrameLocals", out var localsEl));
+            Assert.True(root.TryGetProperty("recentOutput", out _));
+
+            // `id` should still be in scope after a step inside the lambda body.
+            var hasId = false;
+            foreach (var scope in localsEl.EnumerateArray())
+            foreach (var v in scope.GetProperty("variables").EnumerateArray())
+            {
+                if (v.GetProperty("name").GetString() == "id"
+                    && v.GetProperty("value").GetString() == "42")
+                {
+                    hasId = true;
+                }
+            }
+            Assert.True(hasId, "post-step top frame should still expose id=42");
+            postStepThreadId = stopEl.GetProperty("threadId").GetInt32();
+        }
+
+        await manager.ContinueAsync(postStepThreadId, cts.Token);
+        var response = await requestTask;
+        Assert.True(response.IsSuccessStatusCode);
+        await manager.DisconnectAsync(cts.Token);
+    }
+
+    [Fact]
+    public async Task Tool_ExceptionAutopsy_IncludesRecentOutputField()
+    {
+        var bundled = LocateBundledNetcoredbg();
+        if (bundled is null) return;
+
+        var webApiDll = LocateBuiltAssembly("SampleWebApi");
+        var programCs = LocateSourceFile("SampleWebApi", "Program.cs");
+        var port = GetFreeTcpPort();
+        var baseUrl = $"http://127.0.0.1:{port}";
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+        await using var manager = new DebugSessionManager();
+        var inspectTools = new InspectionTools(manager);
+
+        await manager.LaunchAsync(
+            program: webApiDll, args: new[] { "--urls", baseUrl },
+            cwd: Path.GetDirectoryName(webApiDll), stopAtEntry: false, env: null, cts.Token);
+
+        const int handlerLine = 6;
+        await manager.AddLineBreakpointAsync(
+            sourcePath: programCs, line: handlerLine,
+            condition: null, hitCondition: null, logMessage: null, cts.Token);
+
+        await WaitForWebApiReadyAsync(baseUrl, cts.Token);
+
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+        var requestTask = http.GetAsync($"{baseUrl}/users/42", cts.Token);
+
+        var stop = await manager.WaitForStopAsync(
+            timeout: TimeSpan.FromSeconds(20),
+            maxLocalsPerScope: 30, maxRecentOutputLines: 50, cts.Token);
+        Assert.Equal("breakpoint", stop.Stop.Reason);
+
+        // Autopsy doesn't require an exception stop — exceptionInfo is best-effort
+        // and the rest (frames, locals, snippet) populates on any stop. That's enough
+        // to verify the new recentOutput field is wired through.
+        var autopsyJson = await inspectTools.AutopsyAsync(
+            threadId: stop.Stop.ThreadId,
+            frameCount: 5,
+            maxRecentOutputLines: 50,
+            ct: cts.Token);
+
+        using (var doc = JsonDocument.Parse(autopsyJson))
+        {
+            var root = doc.RootElement;
+            Assert.True(root.GetProperty("success").GetBoolean(),
+                $"autopsy failed: {autopsyJson}");
+            Assert.True(root.TryGetProperty("autopsy", out _));
+            Assert.True(root.TryGetProperty("recentOutput", out var recentEl),
+                "autopsy response must include recentOutput field");
+            Assert.Equal(JsonValueKind.Array, recentEl.ValueKind);
+        }
+
+        // Verify the opt-out path: maxRecentOutputLines = 0 sets the field to null,
+        // and the shared JSON serializer (WhenWritingNull) drops it from the wire.
+        var optOutJson = await inspectTools.AutopsyAsync(
+            threadId: stop.Stop.ThreadId,
+            frameCount: 5,
+            maxRecentOutputLines: 0,
+            ct: cts.Token);
+        using (var doc = JsonDocument.Parse(optOutJson))
+        {
+            var root = doc.RootElement;
+            Assert.True(root.GetProperty("success").GetBoolean());
+            Assert.False(root.TryGetProperty("recentOutput", out _),
+                "opt-out (maxRecentOutputLines=0) must omit recentOutput from the response");
+        }
+
+        await manager.ContinueAsync(stop.Stop.ThreadId, cts.Token);
+        var response = await requestTask;
+        Assert.True(response.IsSuccessStatusCode);
         await manager.DisconnectAsync(cts.Token);
     }
 


### PR DESCRIPTION
## Summary
- Extends the convergence pattern from #32 to the tools agents call **between** waits. Today an agent gets a full snapshot at `breakpoint_wait` and then immediately loses it the moment they step — this closes that gap.
- `debug_step`: new opt-in `waitTimeoutSeconds` param (default `0` → today's behavior unchanged). When `> 0`, chains the step with `WaitForStopAsync` and returns the same enriched shape as `breakpoint_wait` (stop, topFrame, snippet, topFrameLocals, recentOutput) in a single tool call.
- `exception_autopsy`: response now includes a non-destructive `recentOutput` peek of recent debuggee stdout/stderr (default 50 lines, pass `0` to omit). Useful for seeing what the app was logging right before a throw without a separate `process_read_output` call.
- `DebugSessionManager`: small `PeekRecentOutput` passthrough added next to the existing `DrainOutput`.

## What does NOT change
- `breakpoint_wait` — untouched.
- `debug_step` with no `waitTimeoutSeconds` returns exactly `{ success, state }` as before — regression-guarded by a dedicated test.
- No new tools, no renamed methods, no schema migration. The new fields on `exception_autopsy` are additive.

## Test plan
- [x] Unit tests: 111/111 pass (unchanged).
- [x] Integration tests: 6/6 pass, including 3 new tests:
  - `Tool_DebugStep_DefaultReturnsSimpleShape_NoEnrichment` — regression guard proving the default response shape is unchanged.
  - `Tool_DebugStep_OptInWaitReturnsEnrichedSnapshot` — proves the opt-in path returns the full enriched snapshot (stop reason = `step`, `id=42` still in post-step locals).
  - `Tool_ExceptionAutopsy_IncludesRecentOutputField` — covers both the populated default and the opt-out (`maxRecentOutputLines: 0`) variants.
- [x] Stability: 117/117 tests pass across 3 consecutive full-suite runs and 3 integration-only runs (~9s each). No leaked `netcoredbg` or `SampleWebApi` processes between iterations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)