### PR TITLE
Don't terminate the debuggee when disconnecting from an attached process

### DIFF
--- a/src/AspNetCoreDebuggerMcp/Debugging/DebugSession.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/DebugSession.cs
@@ -25,6 +25,7 @@ internal sealed class DebugSession : IAsyncDisposable
     private readonly object _gate = new();
     private int? _processId;
     private StopInfo? _lastStop;
+    private bool _isLaunch;
 
     public SessionState State => _stateMachine.State;
     public int? ProcessId { get { lock (_gate) return _processId; } }
@@ -143,6 +144,8 @@ internal sealed class DebugSession : IAsyncDisposable
     private async Task HandshakeAsync(
         bool isLaunch, Dictionary<string, object?> startArgs, CancellationToken ct)
     {
+        _isLaunch = isLaunch;
+
         var initialize = await _client.SendRequestAsync("initialize", new
         {
             clientID = "aspnetcore-debugger-mcp",
@@ -177,7 +180,7 @@ internal sealed class DebugSession : IAsyncDisposable
     {
         try
         {
-            await _client.SendRequestAsync("disconnect", new { terminateDebuggee = true }, ct)
+            await _client.SendRequestAsync("disconnect", new { terminateDebuggee = _isLaunch }, ct)
                 .ConfigureAwait(false);
         }
         catch


### PR DESCRIPTION
`DisconnectAsync` always sent `terminateDebuggee = true`, so `debug_disconnect` killed a process that `debug_attach` had only attached to. DAP defaults this to `false` for attach sessions for that reason.

`HandshakeAsync` already receives `isLaunch`, so the fix is to keep it and pass it through.

### Repro

Against a long-running .NET app on Windows (`win-x64`, bundled netcoredbg 3.1.3-1):

1. `debug_attach` with the app's pid — succeeds, `state: Running`
2. `debug_disconnect` — succeeds
3. The app is gone

A following `debug_attach` then fails with `configurationDone failed: 0x80070057`, which is really just the attach hitting a dead process — that made it look like flaky attach rather than a disconnect problem.

After the change, the same sequence leaves the process running, and attach → pause → `stacktrace_get` → continue → disconnect returns real frames with the app still alive afterwards.

### Notes

- Launch sessions are unaffected: they still terminate on disconnect.
- `dotnet test` on Windows: 111 passed, 6 failed — the same 6 before and after this change (path-handling tests in `NetcoredbgLocatorTests` plus `TraceRendererTests`, which look like they assume POSIX paths; CI runs ubuntu/macos only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)