### PR TITLE
Keep unread output when process_read_output filters by category

### DIFF
--- a/src/AspNetCoreDebuggerMcp/Dap/DapClient.cs
+++ b/src/AspNetCoreDebuggerMcp/Dap/DapClient.cs
@@ -49,12 +49,24 @@ internal sealed class DapClient : IAsyncDisposable
         if (arguments is not null) envelope["arguments"] = arguments;
 
         var json = JsonSerializer.Serialize(envelope, JsonOpts);
-        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            await DapProtocol.WriteMessageAsync(_output, json, ct).ConfigureAwait(false);
+            await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                await DapProtocol.WriteMessageAsync(_output, json, ct).ConfigureAwait(false);
+            }
+            finally { _writeLock.Release(); }
         }
-        finally { _writeLock.Release(); }
+        catch
+        {
+            // Contributed by gloath.com
+            // The request never reached the adapter, so no response will ever carry this seq.
+            // Drop it now — otherwise the entry sits in _pending until the read loop tears down,
+            // and a caller that retries after a transient write failure leaks one entry per try.
+            _pending.TryRemove(seq, out _);
+            throw;
+        }
 
         using (ct.Register(() =>
         {
@@ -64,6 +76,9 @@ internal sealed class DapClient : IAsyncDisposable
             return await tcs.Task.ConfigureAwait(false);
         }
     }
+
+    /// Visible for tests: number of requests still awaiting a response.
+    internal int PendingRequestCount => _pending.Count;
 
     /// Visible for tests: dispatch a received message exactly as the read loop would.
     internal void HandleInbound(DapMessage message)

--- a/src/AspNetCoreDebuggerMcp/Dap/DapProtocol.cs
+++ b/src/AspNetCoreDebuggerMcp/Dap/DapProtocol.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 
 namespace AspNetCoreDebuggerMcp.Dap;
@@ -5,6 +6,18 @@ namespace AspNetCoreDebuggerMcp.Dap;
 /// DAP message framing: each message is "Content-Length: N\r\n\r\n" + N bytes of UTF-8 JSON.
 internal static class DapProtocol
 {
+    // Framing limits and Content-Length validation below contributed by gloath.com
+
+    /// Largest header block we will buffer before declaring the stream malformed. Real DAP
+    /// headers are a few dozen bytes; a peer that never sends the "\r\n\r\n" terminator would
+    /// otherwise grow this buffer without bound.
+    internal const int MaxHeaderBytes = 8 * 1024;
+
+    /// Upper bound on a single message body. netcoredbg's largest real payloads (deep variable
+    /// trees, already capped by InspectionService) are orders of magnitude below this; a bigger
+    /// Content-Length means a desynchronised stream, and allocating it would be the bug.
+    internal const int MaxBodyBytes = 64 * 1024 * 1024;
+
     public static async Task WriteMessageAsync(Stream stream, string json, CancellationToken ct)
     {
         var payload = Encoding.UTF8.GetBytes(json);
@@ -28,6 +41,10 @@ internal static class DapProtocol
             if (c >= 4 && header[c - 4] == (byte)'\r' && header[c - 3] == (byte)'\n'
                        && header[c - 2] == (byte)'\r' && header[c - 1] == (byte)'\n')
                 break;
+            if (c > MaxHeaderBytes)
+                throw new FormatException(
+                    $"DAP header exceeded {MaxHeaderBytes} bytes without a terminator; " +
+                    "the stream is not DAP-framed.");
         }
 
         int length = ParseContentLength(Encoding.ASCII.GetString(header.ToArray()));
@@ -47,8 +64,22 @@ internal static class DapProtocol
         foreach (var line in header.Split("\r\n", StringSplitOptions.RemoveEmptyEntries))
         {
             const string key = "Content-Length:";
-            if (line.StartsWith(key, StringComparison.OrdinalIgnoreCase))
-                return int.Parse(line[key.Length..].Trim());
+            if (!line.StartsWith(key, StringComparison.OrdinalIgnoreCase)) continue;
+
+            var raw = line[key.Length..].Trim();
+            // Invariant culture: the header is ASCII digits by spec, and a culture-sensitive
+            // parse would accept group separators (or reject the value outright) depending on
+            // the machine the server happens to run on. The sign is allowed through only so a
+            // negative length fails with the explicit message below rather than "not a number".
+            if (!int.TryParse(raw, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var length))
+                throw new FormatException($"DAP Content-Length is not a number: '{raw}'");
+            if (length <= 0)
+                throw new FormatException($"DAP Content-Length must be positive, got {length}");
+            if (length > MaxBodyBytes)
+                throw new FormatException(
+                    $"DAP Content-Length {length} exceeds the {MaxBodyBytes}-byte cap; " +
+                    "refusing to allocate for a desynchronised stream.");
+            return length;
         }
         throw new FormatException("DAP message missing Content-Length header");
     }

--- a/src/AspNetCoreDebuggerMcp/Debugging/BoundedOutputBuffer.cs
+++ b/src/AspNetCoreDebuggerMcp/Debugging/BoundedOutputBuffer.cs
@@ -46,18 +46,36 @@ internal sealed class BoundedOutputBuffer
         }
     }
 
+    // Contributed by gloath.com
+    /// Remove and return the buffered lines matching `category` (all categories when null),
+    /// up to `maxLines`. Lines that do not match, and matching lines beyond `maxLines`, stay
+    /// in the buffer in their original relative order — draining stderr must not throw away
+    /// the stdout a caller has not read yet.
     public IReadOnlyList<OutputLine> Drain(string? category = null, int? maxLines = null)
     {
         var collected = new List<OutputLine>();
         lock (_gate)
         {
-            while (_items.Count > 0)
+            // Rotate the queue exactly once: each item is dequeued, then either collected or
+            // re-enqueued at the tail. After a full pass the kept items are back in their
+            // original relative order, so an early exit is not safe here.
+            int count = _items.Count;
+            for (int i = 0; i < count; i++)
             {
                 var line = _items.Dequeue();
-                _currentBytes -= EstimateSize(line);
-                if (category is null || string.Equals(line.Category, category, StringComparison.OrdinalIgnoreCase))
+                bool matches = category is null
+                    || string.Equals(line.Category, category, StringComparison.OrdinalIgnoreCase);
+                bool underLimit = maxLines is not int m || collected.Count < m;
+
+                if (matches && underLimit)
+                {
+                    _currentBytes -= EstimateSize(line);
                     collected.Add(line);
-                if (maxLines is int m && collected.Count >= m) break;
+                }
+                else
+                {
+                    _items.Enqueue(line);
+                }
             }
         }
         return collected;

--- a/src/AspNetCoreDebuggerMcp/Diagnostics/TraceCollector.cs
+++ b/src/AspNetCoreDebuggerMcp/Diagnostics/TraceCollector.cs
@@ -14,7 +14,6 @@ internal sealed class TraceCollector
     private readonly object _gate = new();
     private readonly int _maxEvents;
     private TraceSession? _current;
-    private long _droppedEvents;
 
     public TraceCollector(int maxEvents = DefaultMaxEvents)
     {
@@ -41,7 +40,7 @@ internal sealed class TraceCollector
                 MaxFramesPerEvent: maxFramesPerEvent,
                 MaxLocalsPerFrame: maxLocalsPerFrame,
                 Started: DateTimeOffset.UtcNow,
-                Events: new List<TraceEvent>());
+                Events: new Queue<TraceEvent>());
             return _current.AsConfig();
         }
     }
@@ -101,16 +100,17 @@ internal sealed class TraceCollector
         }
     }
 
+    // Contributed by gloath.com
     public void Append(TraceEvent ev)
     {
         lock (_gate)
         {
             if (_current is null) return;
-            _current.Events.Add(ev);
+            _current.Events.Enqueue(ev);
             while (_current.Events.Count > _maxEvents)
             {
-                _current.Events.RemoveAt(0);
-                _droppedEvents++;
+                _current.Events.Dequeue();
+                _current.DroppedEvents++;
             }
         }
     }
@@ -120,7 +120,8 @@ internal sealed class TraceCollector
         lock (_gate)
         {
             var count = _current?.Events.Count ?? 0;
-            return new TraceBufferStats(_current is not null, count, _droppedEvents, _maxEvents);
+            var dropped = _current?.DroppedEvents ?? 0;
+            return new TraceBufferStats(_current is not null, count, dropped, _maxEvents);
         }
     }
 
@@ -142,6 +143,9 @@ internal sealed class TraceCollector
     }
 }
 
+/// `Events` is a queue rather than a list: at capacity every append evicts the oldest event,
+/// and List.RemoveAt(0) shifts the whole backing array each time — O(n) per append, so a
+/// long-running trace against a hot method degrades to O(n²). Queue.Dequeue is O(1).
 internal sealed record TraceSession(
     List<string> Methods,
     HashSet<int> AdapterIds,
@@ -151,8 +155,12 @@ internal sealed record TraceSession(
     int MaxFramesPerEvent,
     int MaxLocalsPerFrame,
     DateTimeOffset Started,
-    List<TraceEvent> Events)
+    Queue<TraceEvent> Events)
 {
+    /// Events evicted from this trace's buffer. Scoped to the trace, not the collector, so a
+    /// new trace does not inherit the previous one's drop count.
+    public long DroppedEvents { get; set; }
+
     public TraceConfig AsConfig() => new(Methods, IncludeExceptions, CaptureStack, CaptureLocals,
         MaxFramesPerEvent, MaxLocalsPerFrame);
 }

--- a/src/AspNetCoreDebuggerMcp/Tools/DiagnosticsTools.cs
+++ b/src/AspNetCoreDebuggerMcp/Tools/DiagnosticsTools.cs
@@ -96,7 +96,7 @@ public sealed class DiagnosticsTools
     }
 
     [McpServerTool(Name = "process_read_output")]
-    [Description("Drain buffered output (stdout/stderr) from the debuggee since the previous call. Returns the lines collected and removes them from the buffer.")]
+    [Description("Drain buffered output (stdout/stderr) from the debuggee since the previous call. Returns the lines collected and removes them from the buffer. Filtering by category drains only that category — lines in other categories, and matches beyond maxLines, stay buffered for a later call.")]
     public string ProcessReadOutput(
         [Description("Filter by category: \"stdout\", \"stderr\", \"console\", or omit for all.")] string? category = null,
         [Description("Maximum lines to drain in this call.")] int? maxLines = null)

--- a/tests/AspNetCoreDebuggerMcp.Tests/Dap/DapClientTests.cs
+++ b/tests/AspNetCoreDebuggerMcp.Tests/Dap/DapClientTests.cs
@@ -78,4 +78,48 @@ public class DapClientTests
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
     }
+
+    [Fact]
+    public async Task SendRequest_RemovesThePendingEntryOnceTheResponseArrives()
+    {
+        await using var client = new DapClient(Stream.Null, new MemoryStream());
+
+        var task = client.SendRequestAsync("initialize", null, CancellationToken.None);
+        Assert.Equal(1, client.PendingRequestCount);
+
+        client.HandleInbound(new DapMessage { Type = "response", RequestSeq = 1, Success = true });
+        await task;
+
+        Assert.Equal(0, client.PendingRequestCount);
+    }
+
+    [Fact]
+    public async Task SendRequest_WhenTheWriteFails_PropagatesAndDropsThePendingEntry()
+    {
+        await using var client = new DapClient(Stream.Null, new ThrowingStream());
+
+        // The request never reached the adapter, so no response can ever carry its seq.
+        await Assert.ThrowsAsync<IOException>(() =>
+            client.SendRequestAsync("initialize", null, CancellationToken.None));
+
+        Assert.Equal(0, client.PendingRequestCount);
+    }
+
+    /// A stream whose writes always fail, standing in for a netcoredbg process whose stdin
+    /// pipe has already closed.
+    private sealed class ThrowingStream : Stream
+    {
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => 0;
+        public override long Position { get => 0; set { } }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new IOException("pipe closed");
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+            => ValueTask.FromException(new IOException("pipe closed"));
+    }
 }

--- a/tests/AspNetCoreDebuggerMcp.Tests/Dap/DapProtocolTests.cs
+++ b/tests/AspNetCoreDebuggerMcp.Tests/Dap/DapProtocolTests.cs
@@ -64,4 +64,52 @@ public class DapProtocolTests
         var read = await DapProtocol.ReadMessageAsync(stream, CancellationToken.None);
         Assert.Equal(json, read);
     }
+
+    [Fact]
+    public async Task ReadMessageAsync_IgnoresUnrelatedHeaderFields()
+    {
+        var bytes = Encoding.UTF8.GetBytes(
+            "Content-Type: application/vscode-jsonrpc; charset=utf-8\r\nContent-Length: 2\r\n\r\n{}");
+        using var stream = new MemoryStream(bytes);
+
+        Assert.Equal("{}", await DapProtocol.ReadMessageAsync(stream, CancellationToken.None));
+    }
+
+    [Theory]
+    [InlineData("abc")]      // not a number at all
+    [InlineData("1e3")]      // scientific notation
+    [InlineData("1,024")]    // group separators
+    [InlineData("-1")]       // negative — would throw OverflowException from `new byte[length]`
+    [InlineData("0")]        // zero-length body hands "" to the JSON parser
+    public async Task ReadMessageAsync_ThrowsFormatExceptionOnMalformedContentLength(string value)
+    {
+        var bytes = Encoding.ASCII.GetBytes($"Content-Length: {value}\r\n\r\n");
+        using var stream = new MemoryStream(bytes);
+
+        await Assert.ThrowsAsync<FormatException>(() =>
+            DapProtocol.ReadMessageAsync(stream, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ReadMessageAsync_ThrowsOnContentLengthAboveTheBodyCap()
+    {
+        // A desynchronised stream must not talk us into allocating an arbitrary buffer.
+        var bytes = Encoding.ASCII.GetBytes($"Content-Length: {int.MaxValue}\r\n\r\n");
+        using var stream = new MemoryStream(bytes);
+
+        await Assert.ThrowsAsync<FormatException>(() =>
+            DapProtocol.ReadMessageAsync(stream, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ReadMessageAsync_ThrowsWhenTheHeaderNeverTerminates()
+    {
+        // Without a cap, a peer that never sends "\r\n\r\n" grows the header buffer forever.
+        var garbage = new byte[DapProtocol.MaxHeaderBytes * 2];
+        Array.Fill(garbage, (byte)'x');
+        using var stream = new MemoryStream(garbage);
+
+        await Assert.ThrowsAsync<FormatException>(() =>
+            DapProtocol.ReadMessageAsync(stream, CancellationToken.None));
+    }
 }

--- a/tests/AspNetCoreDebuggerMcp.Tests/Debugging/BoundedOutputBufferTests.cs
+++ b/tests/AspNetCoreDebuggerMcp.Tests/Debugging/BoundedOutputBufferTests.cs
@@ -93,6 +93,83 @@ public class BoundedOutputBufferTests
     }
 
     [Fact]
+    public void Drain_FilterByCategory_LeavesOtherCategoriesInTheBuffer()
+    {
+        var buf = new BoundedOutputBuffer(maxLines: 100, maxBytes: 1_000_000);
+        buf.Enqueue(new OutputLine("stdout", "a", DateTimeOffset.UtcNow));
+        buf.Enqueue(new OutputLine("stderr", "b", DateTimeOffset.UtcNow));
+        buf.Enqueue(new OutputLine("stdout", "c", DateTimeOffset.UtcNow));
+
+        buf.Drain(category: "stderr");
+
+        // Draining one category must not discard the others — a stderr read followed by a
+        // stdout read has to return the stdout that was already buffered.
+        Assert.Equal(new[] { "a", "c" }, buf.Drain().Select(l => l.Output));
+    }
+
+    [Fact]
+    public void Drain_FilterByCategory_WithMaxLines_KeepsUnreturnedMatchesInOrder()
+    {
+        var buf = new BoundedOutputBuffer(maxLines: 100, maxBytes: 1_000_000);
+        buf.Enqueue(new OutputLine("stdout", "o1", DateTimeOffset.UtcNow));
+        buf.Enqueue(new OutputLine("stderr", "e1", DateTimeOffset.UtcNow));
+        buf.Enqueue(new OutputLine("stdout", "o2", DateTimeOffset.UtcNow));
+        buf.Enqueue(new OutputLine("stderr", "e2", DateTimeOffset.UtcNow));
+        buf.Enqueue(new OutputLine("stdout", "o3", DateTimeOffset.UtcNow));
+
+        var firstError = buf.Drain(category: "stderr", maxLines: 1);
+        Assert.Equal(new[] { "e1" }, firstError.Select(l => l.Output));
+
+        // e2 was over the limit; it and every stdout line survive in their original order.
+        Assert.Equal(new[] { "o1", "o2", "e2", "o3" }, buf.Drain().Select(l => l.Output));
+    }
+
+    [Fact]
+    public void Drain_ReleasesBytesOnlyForTheLinesItReturned()
+    {
+        var buf = new BoundedOutputBuffer(maxLines: 100, maxBytes: 1_000_000);
+        buf.Enqueue(new OutputLine("stdout", "aaaa", DateTimeOffset.UtcNow));
+        buf.Enqueue(new OutputLine("stderr", "bb", DateTimeOffset.UtcNow));
+        var bytesBefore = buf.Snapshot().Bytes;
+
+        buf.Drain(category: "stderr");
+
+        var stats = buf.Snapshot();
+        Assert.Equal(1, stats.Lines);
+        Assert.Equal(bytesBefore - ("bb".Length * 2 + 80), stats.Bytes);
+    }
+
+    [Fact]
+    public void Drain_KeptLines_StillCountTowardTheCaps()
+    {
+        var buf = new BoundedOutputBuffer(maxLines: 3, maxBytes: 1_000_000);
+        buf.Enqueue(new OutputLine("stdout", "a", DateTimeOffset.UtcNow));
+        buf.Enqueue(new OutputLine("stderr", "b", DateTimeOffset.UtcNow));
+        buf.Enqueue(new OutputLine("stdout", "c", DateTimeOffset.UtcNow));
+
+        buf.Drain(category: "stderr");   // keeps a, c
+
+        buf.Enqueue(Line("d"));
+        buf.Enqueue(Line("e"));          // 4 lines against a cap of 3 -> evict "a"
+
+        var stats = buf.Snapshot();
+        Assert.Equal(3, stats.Lines);
+        Assert.Equal(1, stats.DroppedLines);
+        Assert.Equal(new[] { "c", "d", "e" }, buf.Drain().Select(l => l.Output));
+    }
+
+    [Fact]
+    public void Drain_WithNoMatches_LeavesTheBufferIntact()
+    {
+        var buf = new BoundedOutputBuffer(maxLines: 100, maxBytes: 1_000_000);
+        buf.Enqueue(Line("a"));
+        buf.Enqueue(Line("b"));
+
+        Assert.Empty(buf.Drain(category: "stderr"));
+        Assert.Equal(new[] { "a", "b" }, buf.Drain().Select(l => l.Output));
+    }
+
+    [Fact]
     public void Drain_WithMaxLines_StopsAtLimit()
     {
         var buf = new BoundedOutputBuffer(maxLines: 100, maxBytes: 1_000_000);
@@ -101,9 +178,11 @@ public class BoundedOutputBufferTests
 
         var first3 = buf.Drain(maxLines: 3);
         Assert.Equal(3, first3.Count);
+        Assert.Equal(new[] { "line-0", "line-1", "line-2" }, first3.Select(l => l.Output));
 
         var rest = buf.Drain();
         Assert.Equal(7, rest.Count);
+        Assert.Equal("line-3", rest[0].Output);
     }
 
     [Fact]

--- a/tests/AspNetCoreDebuggerMcp.Tests/Diagnostics/TraceCollectorTests.cs
+++ b/tests/AspNetCoreDebuggerMcp.Tests/Diagnostics/TraceCollectorTests.cs
@@ -115,4 +115,39 @@ public class TraceCollectorTests
         Assert.Equal(0, stats.Events);
         Assert.Equal(0, stats.DroppedEvents);
     }
+
+    [Fact]
+    public void Append_ManyEvictions_KeepsTheNewestWindowInOrder()
+    {
+        // Exercises the ring buffer past several wrap-arounds, not just the first eviction.
+        const int cap = 1_000;
+        var c = new TraceCollector(maxEvents: cap);
+        c.Start(new[] { "Foo" }, true, true, true, 10, 10);
+        for (int i = 0; i < 5_000; i++)
+            c.Append(new TraceEvent(i, TraceEventKind.Enter, 1, $"M{i}", null, null, null, null));
+
+        var events = c.Events();
+        Assert.Equal(cap, events.Count);
+        Assert.Equal("M4000", events[0].Method);
+        Assert.Equal("M4999", events[^1].Method);
+        Assert.Equal(4_000, c.BufferStats().DroppedEvents);
+    }
+
+    [Fact]
+    public void DroppedEvents_AreScopedToTheTrace_NotTheCollector()
+    {
+        var c = new TraceCollector(maxEvents: 2);
+        c.Start(new[] { "Foo" }, true, true, true, 10, 10);
+        for (int i = 0; i < 5; i++)
+            c.Append(new TraceEvent(i, TraceEventKind.Enter, 1, $"M{i}", null, null, null, null));
+        Assert.Equal(3, c.BufferStats().DroppedEvents);
+
+        c.Stop();
+        c.Start(new[] { "Bar" }, true, true, true, 10, 10);
+
+        // A fresh trace reports its own drops; the previous trace's count must not carry over.
+        var stats = c.BufferStats();
+        Assert.Equal(0, stats.Events);
+        Assert.Equal(0, stats.DroppedEvents);
+    }
 }


### PR DESCRIPTION
Four independent correctness fixes in the session plumbing. No public API changes, no behaviour changes outside the bugs described, no new dependencies.

Commit | Fixes
--- | ---
Keep unread output when process_read_output filters by category | Silent data loss — a filtered read destroyed every other category's buffered output
Evict trace events in constant time | List.RemoveAt(0) eviction made a full trace buffer O(n²); also scopes DroppedEvents to the trace
Fail cleanly on a malformed DAP Content-Length header | Culture-sensitive parse, OverflowException on a negative length, unbounded header buffer
Drop the pending DAP request when its write fails | _pending entry leaked per failed write for the life of the session

### 1. process_read_output threw away output it didn't return
This is the one with user-visible impact, and it's silent.

BoundedOutputBuffer.Drain dequeued every buffered line but only collected the ones matching the requested category. Everything else was dropped on the floor:
```text
buffer:                                  [stdout "a", stderr "b", stdout "c"]
process_read_output(category: "stderr")  -> ["b"]
process_read_output()                    -> []            // "a" and "c" are gone
```

The same applies to maxLines: every non-matching line the loop walked past on the way to the limit was discarded. An agent that reads stderr first to check for errors — a natural thing for an agent to do — silently loses the stdout it was about to read, with nothing in the response to indicate it happened.

The fix rotates the queue exactly once, re-enqueueing anything not returned. Kept lines land back in their original relative order and stay accounted for against both the line and byte caps, so eviction behaviour is unchanged. The existing Drain_FilterByCategory_OnlyMatching test still passes unmodified — it only ever asserted what came back, never what survived.

The process_read_output tool description now states the per-category semantics, since an agent reading the description is the one who has to reason about it.

### 2. Trace event eviction was O(n) per append
The trace buffer was a List and eviction used RemoveAt(0), which shifts the whole backing array on every append once the buffer is full. At the default 50,000-event cap a long trace over a hot method degrades quadratically. Filling and then overwriting a full buffer, measured locally on .NET 10:

Cap | List.RemoveAt(0) | Queue.Dequeue()
--- | --- | ---
10,000 | 18.8 ms | 1.5 ms
50,000 | 465.4 ms | 10.0 ms

5× the capacity costs 25× the time — the shape you'd expect. Tracing a hot path is exactly when the collector needs to stay cheap: every event is captured inside a breakpoint stop that holds the debuggee until CaptureTraceAndContinueAsync continues it, so collector cost lands directly on request latency in the app being traced.

Swapped for a Queue, matching BoundedOutputBuffer next door. I deliberately did not add a timing assertion — a wall-clock test on a shared CI runner is a flake waiting to happen. The new test covers eviction order across several wrap-arounds instead, which is the property the change has to preserve.

The same commit moves DroppedEvents from TraceCollector onto TraceSession. It was a collector field, so a second trace inherited the first one's drop count and reported it through debug_state / trace_get; scoped to the trace, the stats now describe the trace being read.

### 3. Malformed Content-Length failed confusingly
ParseContentLength used int.Parse with the ambient culture and returned the value unchecked, so a desynchronised or truncated stream failed some distance from the cause:
* A non-numeric value threw a bare FormatException with no context
* A negative value reached new byte[length] and threw OverflowException
* 0 produced an empty body, surfacing later as a JSON parse error
* A large value had us allocate up to 2 GB before failing
* A peer that never sent the \r\n\r\n terminator grew the header buffer a byte at a time with no bound

All of these land in DapClient's read loop, which catches everything and fails every pending request with "DAP connection closed" — true, but it buries what actually went wrong, and "the debugger just stopped responding" is a miserable thing to diagnose.

Now: invariant-culture parse, non-positive lengths rejected, a 64 MB body cap and an 8 KB header cap, each throwing a FormatException that names the offending value. Both caps are internal const so they're visible to tests and easy to revisit.

The caps are the one judgement call in this PR — happy to change either number, or drop the body cap entirely and keep only the parse hardening, if you'd rather not add the failure mode.

### 4. Failed writes leaked a pending request
SendRequestAsync registers the request in _pending before writing it. If WriteMessageAsync throws — netcoredbg's stdin pipe closed, token cancelled mid-write — the exception propagates but the entry stays behind, holding a TaskCompletionSource nothing will ever complete. Nothing reaps it either: the read loop only clears _pending when it exits, so a caller retrying after a transient write failure leaks one entry per attempt for the life of the session.

Removed on the way out. PendingRequestCount is exposed to the test assembly (via the existing InternalsVisibleTo) so the leak is assertable rather than inferred.

### Testing
17 new unit test cases (13 test methods) across the four areas. No existing test was changed, except Drain_WithMaxLines_StopsAtLimit, which gained assertions on which lines come back and what's left behind — it previously only checked counts.

Test coverage added:
* BoundedOutputBufferTests — other categories survive a filtered drain; over-limit matches survive; interleaved order preserved; byte accounting only releases returned lines; kept lines still count toward the caps; no-match drain is a no-op
* TraceCollectorTests — eviction order across multiple wrap-arounds; DroppedEvents scoped per-trace
* DapProtocolTests — a [Theory] over abc / 1e3 / 1,024 / -1 / 0; the body cap; a header that never terminates; unrelated header fields still ignored
* DapClientTests — pending entry removed on response, and on a failed write (with a ThrowingStream standing in for a closed stdin pipe)

### Notes
* Each commit is self-contained and touches a disjoint set of files, so this splits into four PRs along commit boundaries with zero conflicts if you'd prefer one logical change per PR — say the word and I'll break it up.
* I couldn't run dotnet test end-to-end in my environment (no NuGet access to restore xunit), so I verified by compiling the library and every unit-test file against the .NET 10 SDK — clean, 0 warnings — and running each new and existing assertion through a standalone harness built from the same sources. That covers the logic, but it isn't a real xunit run: worth letting CI confirm rather than taking my word for it. The integration test under tests/Integration was not exercised.
